### PR TITLE
feat: implement chandrayaan v2 task engine and adaptive assignment

### DIFF
--- a/lunar_ops/rover_ws/src/rover_core/rover_core/chandrayaan_task_catalog.json
+++ b/lunar_ops/rover_ws/src/rover_core/rover_core/chandrayaan_task_catalog.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": "2.0.0",
+  "catalog_name": "chandrayaan_swarm_task_catalog",
+  "difficulty_levels": {
+    "L1": {
+      "base_fault_rate": 0.01,
+      "duration_multiplier": 0.7,
+      "min_battery": 0.12,
+      "energy_drain_per_step": 0.002
+    },
+    "L2": {
+      "base_fault_rate": 0.03,
+      "duration_multiplier": 0.9,
+      "min_battery": 0.18,
+      "energy_drain_per_step": 0.003
+    },
+    "L3": {
+      "base_fault_rate": 0.06,
+      "duration_multiplier": 1.1,
+      "min_battery": 0.25,
+      "energy_drain_per_step": 0.004
+    },
+    "L4": {
+      "base_fault_rate": 0.1,
+      "duration_multiplier": 1.35,
+      "min_battery": 0.32,
+      "energy_drain_per_step": 0.0055
+    },
+    "L5": {
+      "base_fault_rate": 0.18,
+      "duration_multiplier": 1.7,
+      "min_battery": 0.42,
+      "energy_drain_per_step": 0.007
+    }
+  },
+  "task_types": {
+    "movement": {
+      "display_name": "Movement/Traverse",
+      "mission_phase": "CY3-ops",
+      "required_capabilities": ["mobility"],
+      "base_steps": 8,
+      "min_steps": 4,
+      "max_steps": 30,
+      "terrain_sensitivity": 1.0,
+      "solar_sensitivity": 0.7,
+      "comm_sensitivity": 0.5,
+      "thermal_sensitivity": 0.6,
+      "battery_sensitivity": 0.9,
+      "terrain_duration_sensitivity": 0.45,
+      "risk_floor": 0.005
+    },
+    "science": {
+      "display_name": "Science Investigation",
+      "mission_phase": "CY3-ops",
+      "required_capabilities": ["science", "imaging"],
+      "base_steps": 10,
+      "min_steps": 5,
+      "max_steps": 36,
+      "terrain_sensitivity": 0.5,
+      "solar_sensitivity": 0.6,
+      "comm_sensitivity": 0.7,
+      "thermal_sensitivity": 0.8,
+      "battery_sensitivity": 0.7,
+      "terrain_duration_sensitivity": 0.25,
+      "risk_floor": 0.008
+    },
+    "digging": {
+      "display_name": "Digging/Drilling/Excavation",
+      "mission_phase": "LUPEX-prospecting",
+      "required_capabilities": ["excavation"],
+      "base_steps": 12,
+      "min_steps": 6,
+      "max_steps": 42,
+      "terrain_sensitivity": 0.8,
+      "solar_sensitivity": 0.5,
+      "comm_sensitivity": 0.4,
+      "thermal_sensitivity": 0.9,
+      "battery_sensitivity": 1.0,
+      "terrain_duration_sensitivity": 0.35,
+      "risk_floor": 0.01
+    },
+    "pushing": {
+      "display_name": "Pushing/Transport/Regolith Handling",
+      "mission_phase": "base-build",
+      "required_capabilities": ["manipulation", "mobility"],
+      "base_steps": 11,
+      "min_steps": 6,
+      "max_steps": 40,
+      "terrain_sensitivity": 0.9,
+      "solar_sensitivity": 0.4,
+      "comm_sensitivity": 0.4,
+      "thermal_sensitivity": 0.7,
+      "battery_sensitivity": 1.0,
+      "terrain_duration_sensitivity": 0.4,
+      "risk_floor": 0.01
+    },
+    "photo": {
+      "display_name": "Photo/Imaging/Survey",
+      "mission_phase": "CY3-ops",
+      "required_capabilities": ["imaging"],
+      "base_steps": 6,
+      "min_steps": 3,
+      "max_steps": 24,
+      "terrain_sensitivity": 0.3,
+      "solar_sensitivity": 0.5,
+      "comm_sensitivity": 0.8,
+      "thermal_sensitivity": 0.4,
+      "battery_sensitivity": 0.4,
+      "terrain_duration_sensitivity": 0.15,
+      "risk_floor": 0.004
+    },
+    "sample-handling": {
+      "display_name": "Sample Handling/Transfer",
+      "mission_phase": "CY4-sample-chain",
+      "required_capabilities": ["sample-logistics", "manipulation"],
+      "base_steps": 9,
+      "min_steps": 5,
+      "max_steps": 32,
+      "terrain_sensitivity": 0.6,
+      "solar_sensitivity": 0.5,
+      "comm_sensitivity": 0.6,
+      "thermal_sensitivity": 0.8,
+      "battery_sensitivity": 0.8,
+      "terrain_duration_sensitivity": 0.3,
+      "risk_floor": 0.009
+    }
+  }
+}

--- a/lunar_ops/rover_ws/src/rover_core/rover_core/rover_node.py
+++ b/lunar_ops/rover_ws/src/rover_core/rover_core/rover_node.py
@@ -8,16 +8,17 @@ from rclpy.node import Node
 
 from std_msgs.msg import String
 
+from .task_model import compute_fault_probability
+from .task_model import compute_task_duration_steps
+from .task_model import get_lunar_time_state
+from .task_model import get_rover_capabilities
+from .task_model import load_catalog
+from .task_model import normalize_task_request
+
 
 class RoverNode(Node):
-    """Autonomous rover with realistic state machine behavior.
+    """Autonomous rover with context-aware task execution model."""
 
-    Supports multi-rover constellations via configurable rover_id parameter.
-    Each instance uses namespaced topics: /rover/{id}/downlink_telemetry,
-    /rover/{id}/command, /rover/{id}/ack.
-    """
-
-    # Valid states
     STATE_IDLE = 'IDLE'
     STATE_EXECUTING = 'EXECUTING'
     STATE_SAFE_MODE = 'SAFE_MODE'
@@ -26,71 +27,101 @@ class RoverNode(Node):
     def __init__(self):
         super().__init__('rover_node')
 
-        # --- Rover identity ---
         self.declare_parameter('rover_id', 'rover_1')
-        self.rover_id = self.get_parameter('rover_id').value
+        self.declare_parameter('task_catalog_path', '')
 
-        # State machine
+        self.rover_id = self.get_parameter('rover_id').value
+        self.task_catalog = load_catalog(
+            str(self.get_parameter('task_catalog_path').value).strip() or None
+        )
+
         self.state = self.STATE_IDLE
         self.current_task_id = None
+        self.active_task_type = None
+        self.active_task_difficulty = None
+        self.active_task_mission_phase = None
+        self.active_task_required_capabilities = []
+        self.assignment_score_breakdown = None
+        self.task_total_steps = 0
         self.task_counter = 0
-        self.fault_probability = 0.1
+        self.predicted_fault_probability = 0.0
         self.battery_level = 1.0
         self.last_fault = None
+        self.capabilities = sorted(get_rover_capabilities(self.rover_id))
 
-        # --- Simulated sensor data ---
         self.position = {
             'lat': round(random.uniform(-45.0, 45.0), 6),
             'lon': round(random.uniform(-180.0, 180.0), 6),
         }
         self.solar_exposure = round(random.uniform(0.6, 1.0), 2)
         self._solar_phase = random.uniform(0, 2 * math.pi)
+        self.lunar_time_state = get_lunar_time_state(self.solar_exposure)
+        self.terrain_difficulty = round(random.uniform(0.2, 0.65), 2)
+        self.comm_quality = round(random.uniform(0.72, 0.94), 2)
+        self.thermal_stress = round(random.uniform(0.15, 0.45), 2)
         self.data_buffer_size = 0
 
-        # --- Namespaced topics ---
         topic_prefix = f'/rover/{self.rover_id}'
-
         self.telemetry_pub = self.create_publisher(
             String,
             f'{topic_prefix}/downlink_telemetry',
-            10
+            10,
         )
-
-        self.ack_pub = self.create_publisher(
-            String,
-            f'{topic_prefix}/ack',
-            10
-        )
-
+        self.ack_pub = self.create_publisher(String, f'{topic_prefix}/ack', 10)
         self.command_sub = self.create_subscription(
             String,
             f'{topic_prefix}/command',
             self.command_callback,
-            10
+            10,
         )
 
         self.timer = self.create_timer(2.0, self.publish_telemetry)
         self.task_timer = self.create_timer(1.0, self.execute_task_step)
 
         self.get_logger().info(
-            f'🤖 Rover [{self.rover_id}] initialized in {self.state} state\n'
-            f'   Topics: {topic_prefix}/{{downlink_telemetry,command,ack}}'
+            f'Rover [{self.rover_id}] initialized in {self.state} state\n'
+            f'Capabilities={self.capabilities}\n'
+            f'Topics: {topic_prefix}/{{downlink_telemetry,command,ack}}'
         )
+
+    def _clear_active_task(self):
+        self.current_task_id = None
+        self.active_task_type = None
+        self.active_task_difficulty = None
+        self.active_task_mission_phase = None
+        self.active_task_required_capabilities = []
+        self.assignment_score_breakdown = None
+        self.task_total_steps = 0
+        self.task_counter = 0
+        self.predicted_fault_probability = 0.0
 
     def command_callback(self, msg):
         """Process JSON commands from Earth with autonomous decision-making."""
+        cmd_data = {}
         try:
             cmd_data = json.loads(msg.data)
             cmd_id = cmd_data.get('cmd_id', 'unknown')
             cmd_type = cmd_data.get('type')
-            task_id = cmd_data.get('task_id')
 
             self.get_logger().info(
-                f'📡 [{self.rover_id}] Command received [{cmd_id}]: {cmd_type}'
+                f'[{self.rover_id}] Command received [{cmd_id}]: {cmd_type}'
             )
 
             if cmd_type == 'START_TASK':
-                success, reason = self.handle_start_task(task_id)
+                success, reason = self.handle_start_task(
+                    task_id=cmd_data.get('task_id'),
+                    task_type=cmd_data.get('task_type'),
+                    difficulty_level=cmd_data.get('difficulty_level'),
+                    mission_phase=cmd_data.get('mission_phase'),
+                    required_capabilities=cmd_data.get('required_capabilities'),
+                    target_site=cmd_data.get('target_site'),
+                    assignment_score_breakdown=cmd_data.get(
+                        'assignment_score_breakdown'
+                    ),
+                    predicted_fault_probability=cmd_data.get(
+                        'predicted_fault_probability'
+                    ),
+                )
                 self.send_ack(cmd_id, success, reason)
             elif cmd_type == 'ABORT':
                 success, reason = self.handle_abort()
@@ -102,43 +133,107 @@ class RoverNode(Node):
                 success, reason = self.handle_reset()
                 self.send_ack(cmd_id, success, reason)
             else:
-                self.get_logger().warn(
-                    f'⚠️  Unknown command type: {cmd_type}'
-                )
-                self.send_ack(
-                    cmd_id, False, f'Unknown command type: {cmd_type}'
-                )
+                self.send_ack(cmd_id, False, f'Unknown command type: {cmd_type}')
 
-        except json.JSONDecodeError as e:
-            self.get_logger().error(
-                f'Failed to parse command JSON: {msg.data}'
-            )
-            self.send_ack('unknown', False, f'Invalid JSON: {e}')
-        except Exception as e:
-            self.get_logger().error(f'Error processing command: {e}')
-            self.send_ack(
-                cmd_data.get('cmd_id', 'unknown'), False, f'Error: {e}'
-            )
+        except json.JSONDecodeError as exc:
+            self.get_logger().error(f'Failed to parse command JSON: {msg.data}')
+            self.send_ack('unknown', False, f'Invalid JSON: {exc}')
+        except Exception as exc:
+            self.get_logger().error(f'Error processing command: {exc}')
+            self.send_ack(cmd_data.get('cmd_id', 'unknown'), False, f'Error: {exc}')
 
-    def handle_start_task(self, task_id):
+    def handle_start_task(
+        self,
+        task_id,
+        task_type=None,
+        difficulty_level=None,
+        mission_phase=None,
+        required_capabilities=None,
+        target_site=None,
+        assignment_score_breakdown=None,
+        predicted_fault_probability=None,
+    ):
         """Start a new task if conditions allow."""
         if self.state == self.STATE_SAFE_MODE:
-            reason = ('Cannot start task: Rover in SAFE_MODE. '
-                      'Send RESET first.')
-            self.get_logger().warn(f'❌ {reason}')
+            reason = 'Cannot start task: Rover in SAFE_MODE. Send RESET first.'
+            self.get_logger().warn(reason)
             return False, reason
 
         if self.state == self.STATE_EXECUTING:
-            reason = (f'Cannot start task: Already executing '
-                      f'task {self.current_task_id}')
-            self.get_logger().warn(f'❌ {reason}')
+            reason = (
+                f'Cannot start task: Already executing task {self.current_task_id}'
+            )
+            self.get_logger().warn(reason)
             return False, reason
 
+        task_request = normalize_task_request(
+            self.task_catalog,
+            task_id=task_id,
+            task_type=task_type,
+            difficulty_level=difficulty_level,
+            mission_phase=mission_phase,
+            required_capabilities=required_capabilities,
+            target_site=target_site,
+        )
+
+        required_caps = set(task_request['required_capabilities'])
+        capability_set = set(self.capabilities)
+        if not required_caps.issubset(capability_set):
+            reason = (
+                f'Cannot start task: Missing capabilities for '
+                f'{task_request["task_type"]}'
+            )
+            self.get_logger().warn(reason)
+            return False, reason
+
+        duration_context = {
+            'terrain_difficulty': self.terrain_difficulty,
+            'comm_quality': self.comm_quality,
+        }
+        self.task_total_steps = compute_task_duration_steps(
+            self.task_catalog,
+            task_request['task_type'],
+            task_request['difficulty_level'],
+            duration_context,
+        )
+
+        risk_context = {
+            'battery': self.battery_level,
+            'solar_intensity': self.solar_exposure,
+            'terrain_difficulty': self.terrain_difficulty,
+            'comm_quality': self.comm_quality,
+            'thermal_stress': self.thermal_stress,
+            'lunar_time_state': self.lunar_time_state,
+            'capability_match': True,
+        }
+        computed_risk, _ = compute_fault_probability(
+            self.task_catalog,
+            task_request['task_type'],
+            task_request['difficulty_level'],
+            risk_context,
+        )
+
         self.state = self.STATE_EXECUTING
-        self.current_task_id = task_id
+        self.current_task_id = task_request['task_id']
+        self.active_task_type = task_request['task_type']
+        self.active_task_difficulty = task_request['difficulty_level']
+        self.active_task_mission_phase = task_request['mission_phase']
+        self.active_task_required_capabilities = list(
+            task_request['required_capabilities']
+        )
+        self.assignment_score_breakdown = assignment_score_breakdown
         self.task_counter = 0
+        self.predicted_fault_probability = (
+            float(predicted_fault_probability)
+            if predicted_fault_probability is not None
+            else computed_risk
+        )
+
         self.get_logger().info(
-            f'✅ [{self.rover_id}] Started task: {task_id}'
+            f'[{self.rover_id}] Started task: {self.current_task_id} '
+            f'({self.active_task_type}/{self.active_task_difficulty}, '
+            f'steps={self.task_total_steps}, '
+            f'risk={self.predicted_fault_probability:.3f})'
         )
         return True, None
 
@@ -146,31 +241,21 @@ class RoverNode(Node):
         """Abort current task if executing."""
         if self.state == self.STATE_EXECUTING:
             self.get_logger().info(
-                f'🛑 [{self.rover_id}] Aborting task: '
-                f'{self.current_task_id}'
+                f'[{self.rover_id}] Aborting task: {self.current_task_id}'
             )
             self.state = self.STATE_IDLE
-            self.current_task_id = None
-            self.task_counter = 0
-            return True, None
-        else:
-            self.get_logger().info(
-                f'ℹ️  ABORT received but rover is {self.state}, '
-                'no task to abort'
-            )
-            return True, None
+            self._clear_active_task()
+        return True, None
 
     def handle_go_safe(self):
         """Enter safe mode immediately."""
         old_state = self.state
         self.state = self.STATE_SAFE_MODE
-        self.current_task_id = None
-        self.task_counter = 0
+        self._clear_active_task()
         if not self.last_fault:
             self.last_fault = 'Commanded to SAFE_MODE'
         self.get_logger().warn(
-            f'⚠️  [{self.rover_id}] Commanded to SAFE_MODE '
-            f'from {old_state}'
+            f'[{self.rover_id}] Commanded to SAFE_MODE from {old_state}'
         )
         return True, None
 
@@ -178,20 +263,12 @@ class RoverNode(Node):
         """Reset from safe mode to idle."""
         if self.state == self.STATE_SAFE_MODE:
             self.state = self.STATE_IDLE
-            self.current_task_id = None
-            self.task_counter = 0
+            self._clear_active_task()
             self.last_fault = None
             self.get_logger().info(
-                f'🔄 [{self.rover_id}] RESET: '
-                'Leaving SAFE_MODE → IDLE'
+                f'[{self.rover_id}] RESET: Leaving SAFE_MODE -> IDLE'
             )
-            return True, None
-        else:
-            self.get_logger().info(
-                f'ℹ️  RESET received but rover is {self.state}, '
-                'not in SAFE_MODE'
-            )
-            return True, None
+        return True, None
 
     def send_ack(self, cmd_id, success, reason=None):
         """Send command acknowledgment to Earth."""
@@ -200,75 +277,111 @@ class RoverNode(Node):
             'rover_id': self.rover_id,
             'status': 'ACCEPTED' if success else 'REJECTED',
             'reason': reason,
-            'ts': time.time()
+            'ts': time.time(),
         }
 
         msg = String()
         msg.data = json.dumps(ack_data)
         self.ack_pub.publish(msg)
 
-        status_str = ('✅ ACCEPTED' if success
-                      else f'❌ REJECTED ({reason})')
-        self.get_logger().info(
-            f'📤 [{self.rover_id}] ACK sent [{cmd_id}]: {status_str}'
+    def _update_solar_exposure(self):
+        self._solar_phase += 0.02
+        base = 0.5 + 0.5 * math.sin(self._solar_phase)
+        noise = random.uniform(-0.05, 0.05)
+        self.solar_exposure = round(max(0.0, min(1.0, base + noise)), 2)
+        self.lunar_time_state = get_lunar_time_state(self.solar_exposure)
+
+    def _update_environmentals(self):
+        self.comm_quality = round(
+            max(0.3, min(1.0, self.comm_quality + random.uniform(-0.03, 0.02))),
+            2,
+        )
+        self.terrain_difficulty = round(
+            max(
+                0.1,
+                min(0.95, self.terrain_difficulty + random.uniform(-0.02, 0.02)),
+            ),
+            2,
+        )
+        thermal_delta = 0.04 if self.lunar_time_state == 'DAYLIGHT' else -0.02
+        self.thermal_stress = round(
+            max(
+                0.05,
+                min(
+                    0.98,
+                    self.thermal_stress
+                    + thermal_delta
+                    + random.uniform(-0.03, 0.03),
+                ),
+            ),
+            2,
         )
 
     def execute_task_step(self):
-        """Simulate autonomous task execution with fault detection."""
+        """Simulate autonomous task execution with dynamic fault modeling."""
         if self.state != self.STATE_EXECUTING:
             return
 
+        self._update_solar_exposure()
+        self._update_environmentals()
         self.task_counter += 1
 
-        # Drain battery during execution (0.5% per step)
-        self.battery_level = max(0.0, self.battery_level - 0.005)
+        difficulty_cfg = self.task_catalog['difficulty_levels'].get(
+            self.active_task_difficulty or 'L2',
+            {},
+        )
+        base_drain = float(difficulty_cfg.get('energy_drain_per_step', 0.003))
+        drain_multiplier = 1.0 + (self.terrain_difficulty * 0.4)
+        self.battery_level = max(
+            0.0,
+            self.battery_level - (base_drain * drain_multiplier),
+        )
 
-        # Accumulate data during task execution
         self.data_buffer_size += random.randint(128, 1024)
-
-        # Simulate small position drift during movement
         self.position['lat'] += random.uniform(-0.0001, 0.0001)
         self.position['lon'] += random.uniform(-0.0001, 0.0001)
         self.position['lat'] = round(self.position['lat'], 6)
         self.position['lon'] = round(self.position['lon'], 6)
 
-        # Simulate fault detection
-        if random.random() < self.fault_probability:
-            fault_msg = (f'Fault during task execution '
-                         f'(step {self.task_counter})')
+        risk_context = {
+            'battery': self.battery_level,
+            'solar_intensity': self.solar_exposure,
+            'terrain_difficulty': self.terrain_difficulty,
+            'comm_quality': self.comm_quality,
+            'thermal_stress': self.thermal_stress,
+            'lunar_time_state': self.lunar_time_state,
+            'capability_match': True,
+        }
+        fault_probability, _ = compute_fault_probability(
+            self.task_catalog,
+            self.active_task_type or 'movement',
+            self.active_task_difficulty or 'L2',
+            risk_context,
+        )
+        self.predicted_fault_probability = fault_probability
+
+        if random.random() < fault_probability:
+            fault_msg = f'Fault during task execution (step {self.task_counter})'
             self.get_logger().error(
-                f'🚨 [{self.rover_id}] FAULT DETECTED during '
-                f'task {self.current_task_id}!'
+                f'[{self.rover_id}] FAULT DETECTED during task {self.current_task_id}'
             )
             self.state = self.STATE_SAFE_MODE
             self.last_fault = fault_msg
-            self.current_task_id = None
-            self.task_counter = 0
+            self._clear_active_task()
             return
 
-        # Simulate task completion after 10 steps
-        if self.task_counter >= 10:
+        if self.task_counter >= max(1, self.task_total_steps):
             self.get_logger().info(
-                f'✅ [{self.rover_id}] Task '
-                f'{self.current_task_id} completed!'
+                f'[{self.rover_id}] Task {self.current_task_id} completed'
             )
             self.state = self.STATE_IDLE
-            self.current_task_id = None
-            self.task_counter = 0
+            self._clear_active_task()
             self.data_buffer_size = 0
         else:
             self.get_logger().info(
-                f'⚙️  [{self.rover_id}] Executing task '
-                f'{self.current_task_id}: '
-                f'step {self.task_counter}/10'
+                f'[{self.rover_id}] Executing task {self.current_task_id}: '
+                f'step {self.task_counter}/{self.task_total_steps}'
             )
-
-    def _update_solar_exposure(self):
-        """Update simulated solar exposure using a slow sine wave."""
-        self._solar_phase += 0.02
-        base = 0.5 + 0.5 * math.sin(self._solar_phase)
-        noise = random.uniform(-0.05, 0.05)
-        self.solar_exposure = round(max(0.0, min(1.0, base + noise)), 2)
 
     def publish_telemetry(self):
         """Publish current state as structured JSON with enriched fields."""
@@ -279,14 +392,29 @@ class RoverNode(Node):
             'rover_id': self.rover_id,
             'state': self.state,
             'task_id': self.current_task_id,
+            'active_task_type': self.active_task_type,
+            'active_task_difficulty': self.active_task_difficulty,
+            'task_total_steps': (
+                self.task_total_steps if self.state == self.STATE_EXECUTING else None
+            ),
             'battery': round(self.battery_level, 2),
             'position': {
                 'lat': self.position['lat'],
                 'lon': self.position['lon'],
             },
             'solar_exposure': self.solar_exposure,
+            'solar_intensity': self.solar_exposure,
+            'lunar_time_state': self.lunar_time_state,
+            'terrain_difficulty': self.terrain_difficulty,
+            'comm_quality': self.comm_quality,
+            'thermal_stress': self.thermal_stress,
+            'predicted_fault_probability': round(
+                self.predicted_fault_probability, 4
+            ),
+            'assignment_score_breakdown': self.assignment_score_breakdown,
             'data_buffer_size': self.data_buffer_size,
             'fault': self.last_fault,
+            'capabilities': self.capabilities,
         }
 
         msg = String()
@@ -295,8 +423,11 @@ class RoverNode(Node):
 
 
 def main():
-    """Entry point for the rover node."""
     rclpy.init()
     node = RoverNode()
     rclpy.spin(node)
     rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/lunar_ops/rover_ws/src/rover_core/rover_core/task_model.py
+++ b/lunar_ops/rover_ws/src/rover_core/rover_core/task_model.py
@@ -1,0 +1,352 @@
+import json
+import math
+import re
+from pathlib import Path
+
+FALLBACK_TASK_TYPE = 'movement'
+FALLBACK_DIFFICULTY = 'L2'
+FALLBACK_MISSION_PHASE = 'CY3-ops'
+
+
+def _clamp(value, low=0.0, high=1.0):
+    return max(low, min(high, value))
+
+
+def _as_float(value, fallback=0.0):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _load_json(path):
+    with path.open('r', encoding='utf-8') as fp:
+        return json.load(fp)
+
+
+def find_catalog_path(explicit_path=None):
+    if explicit_path:
+        candidate = Path(explicit_path).expanduser().resolve()
+        if candidate.exists():
+            return candidate
+
+    local_catalog = Path(__file__).with_name('chandrayaan_task_catalog.json')
+    if local_catalog.exists():
+        return local_catalog
+
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / 'web-sim' / 'assets' / 'chandrayaan_task_catalog.json'
+        if candidate.exists():
+            return candidate
+
+    raise FileNotFoundError('Cannot locate chandrayaan_task_catalog.json')
+
+
+def validate_catalog(catalog):
+    if 'difficulty_levels' not in catalog or 'task_types' not in catalog:
+        raise ValueError('Task catalog missing required keys')
+
+    required_levels = ['L1', 'L2', 'L3', 'L4', 'L5']
+    for level in required_levels:
+        if level not in catalog['difficulty_levels']:
+            raise ValueError(f'Missing difficulty level: {level}')
+
+    required_level_rates = {
+        'L1': 0.01,
+        'L2': 0.03,
+        'L3': 0.06,
+        'L4': 0.10,
+        'L5': 0.18,
+    }
+    for level, expected_rate in required_level_rates.items():
+        actual = float(catalog['difficulty_levels'][level]['base_fault_rate'])
+        if abs(actual - expected_rate) > 1e-9:
+            raise ValueError(
+                f'Unexpected base fault rate for {level}: {actual} (expected {expected_rate})'
+            )
+
+    for task_type, task_cfg in catalog['task_types'].items():
+        for key in ['required_capabilities', 'base_steps', 'mission_phase']:
+            if key not in task_cfg:
+                raise ValueError(f'Task type {task_type} missing key: {key}')
+
+
+def load_catalog(explicit_path=None):
+    catalog_path = find_catalog_path(explicit_path)
+    catalog = _load_json(catalog_path)
+    validate_catalog(catalog)
+    return catalog
+
+
+def get_rover_capabilities(rover_id):
+    rover_str = str(rover_id or '')
+    match = re.search(r'(\d+)$', rover_str)
+    rover_index = int(match.group(1)) if match else 1
+
+    profile_by_mod = {
+        1: {'mobility', 'imaging', 'science'},
+        2: {'mobility', 'science', 'sample-logistics', 'imaging'},
+        0: {'mobility', 'excavation', 'manipulation', 'sample-logistics', 'imaging'},
+    }
+
+    capabilities = set(profile_by_mod.get(rover_index % 3, {'mobility', 'imaging'}))
+    capabilities.add('mobility')
+    return capabilities
+
+
+def normalize_task_request(catalog, task_id, task_type=None, difficulty_level=None,
+                           mission_phase=None, required_capabilities=None,
+                           target_site=None):
+    task_type_key = str(task_type or FALLBACK_TASK_TYPE).strip().lower()
+    if task_type_key not in catalog['task_types']:
+        task_type_key = FALLBACK_TASK_TYPE
+
+    diff_key = str(difficulty_level or FALLBACK_DIFFICULTY).strip().upper()
+    if diff_key not in catalog['difficulty_levels']:
+        diff_key = FALLBACK_DIFFICULTY
+
+    task_cfg = catalog['task_types'][task_type_key]
+
+    if required_capabilities:
+        req_caps = [
+            str(cap).strip().lower()
+            for cap in required_capabilities
+            if str(cap).strip()
+        ]
+    else:
+        req_caps = list(task_cfg.get('required_capabilities', []))
+
+    normalized_task_id = str(task_id or f'{task_type_key}-{diff_key}').strip()
+    if not normalized_task_id:
+        normalized_task_id = f'{task_type_key}-{diff_key}'
+
+    return {
+        'task_id': normalized_task_id,
+        'task_type': task_type_key,
+        'difficulty_level': diff_key,
+        'mission_phase': mission_phase or task_cfg.get('mission_phase', FALLBACK_MISSION_PHASE),
+        'required_capabilities': req_caps,
+        'target_site': target_site,
+    }
+
+
+def get_lunar_time_state(solar_intensity):
+    solar = _clamp(_as_float(solar_intensity, 0.5))
+    if solar >= 0.55:
+        return 'DAYLIGHT'
+    if solar <= 0.30:
+        return 'NIGHT'
+    return 'TERMINATOR'
+
+
+def compute_task_duration_steps(catalog, task_type, difficulty_level, context):
+    task_cfg = catalog['task_types'][task_type]
+    diff_cfg = catalog['difficulty_levels'][difficulty_level]
+
+    base_steps = int(task_cfg['base_steps'])
+    difficulty_multiplier = _as_float(diff_cfg.get('duration_multiplier', 1.0), 1.0)
+    terrain_difficulty = _clamp(_as_float(context.get('terrain_difficulty', 0.3), 0.3))
+    comm_quality = _clamp(_as_float(context.get('comm_quality', 0.8), 0.8))
+
+    terrain_factor = 1.0 + terrain_difficulty * _as_float(
+        task_cfg.get('terrain_duration_sensitivity', 0.3), 0.3
+    )
+    comm_factor = 1.0 + (1.0 - comm_quality) * 0.2
+
+    steps = int(round(base_steps * difficulty_multiplier * terrain_factor * comm_factor))
+    steps = max(int(task_cfg.get('min_steps', 3)), steps)
+    steps = min(int(task_cfg.get('max_steps', 60)), steps)
+    return steps
+
+
+def compute_fault_probability(catalog, task_type, difficulty_level, context):
+    task_cfg = catalog['task_types'][task_type]
+    diff_cfg = catalog['difficulty_levels'][difficulty_level]
+
+    base_risk = _as_float(diff_cfg.get('base_fault_rate', 0.03), 0.03)
+
+    battery = _clamp(_as_float(context.get('battery', 1.0), 1.0))
+    solar = _clamp(_as_float(context.get('solar_intensity', context.get('solar_exposure', 0.5)), 0.5))
+    terrain = _clamp(_as_float(context.get('terrain_difficulty', 0.3), 0.3))
+    comm_quality = _clamp(_as_float(context.get('comm_quality', 0.8), 0.8))
+    thermal_stress = _clamp(_as_float(context.get('thermal_stress', 0.3), 0.3))
+    capability_match = bool(context.get('capability_match', True))
+
+    lunar_state = context.get('lunar_time_state') or get_lunar_time_state(solar)
+
+    battery_penalty = max(0.0, 0.45 - battery) * _as_float(
+        task_cfg.get('battery_sensitivity', 0.8), 0.8
+    ) * 0.22
+    solar_penalty = max(0.0, 0.40 - solar) * _as_float(
+        task_cfg.get('solar_sensitivity', 0.6), 0.6
+    ) * 0.18
+    terrain_penalty = terrain * _as_float(task_cfg.get('terrain_sensitivity', 0.6), 0.6) * 0.12
+    comm_penalty = (1.0 - comm_quality) * _as_float(
+        task_cfg.get('comm_sensitivity', 0.5), 0.5
+    ) * 0.10
+    thermal_penalty = thermal_stress * _as_float(
+        task_cfg.get('thermal_sensitivity', 0.6), 0.6
+    ) * 0.10
+
+    lunar_penalty = {
+        'DAYLIGHT': 0.0,
+        'TERMINATOR': 0.02,
+        'NIGHT': 0.06,
+    }.get(str(lunar_state).upper(), 0.02)
+
+    capability_penalty = 0.0 if capability_match else 0.12
+
+    battery_bonus = max(0.0, battery - 0.80) * 0.03
+    solar_bonus = max(0.0, solar - 0.85) * 0.02
+
+    risk = (
+        base_risk
+        + battery_penalty
+        + solar_penalty
+        + terrain_penalty
+        + comm_penalty
+        + thermal_penalty
+        + lunar_penalty
+        + capability_penalty
+        - battery_bonus
+        - solar_bonus
+    )
+
+    risk = max(_as_float(task_cfg.get('risk_floor', 0.0), 0.0), risk)
+    risk = _clamp(risk, 0.0, 0.6)
+
+    return risk, {
+        'base_risk': round(base_risk, 4),
+        'battery_penalty': round(battery_penalty, 4),
+        'solar_penalty': round(solar_penalty, 4),
+        'terrain_penalty': round(terrain_penalty, 4),
+        'comm_penalty': round(comm_penalty, 4),
+        'thermal_penalty': round(thermal_penalty, 4),
+        'lunar_penalty': round(lunar_penalty, 4),
+        'capability_penalty': round(capability_penalty, 4),
+        'battery_bonus': round(battery_bonus, 4),
+        'solar_bonus': round(solar_bonus, 4),
+        'lunar_time_state': str(lunar_state).upper(),
+    }
+
+
+def _distance_margin(target_site, position):
+    if not target_site or not position:
+        return 0.75
+
+    try:
+        dlat = float(target_site.get('lat', 0.0)) - float(position.get('lat', 0.0))
+        dlon = float(target_site.get('lon', 0.0)) - float(position.get('lon', 0.0))
+    except (TypeError, ValueError):
+        return 0.6
+
+    distance = math.sqrt(dlat ** 2 + dlon ** 2)
+    # scale around a 2-degree mission envelope
+    normalized = _clamp(1.0 - min(distance / 2.0, 1.0), 0.0, 1.0)
+    return normalized
+
+
+def score_rover_for_task(catalog, rover_id, status, task_request):
+    state = str(status.get('state', 'UNKNOWN')).upper()
+    battery = _clamp(_as_float(status.get('battery', 0.0), 0.0))
+    solar = _clamp(_as_float(status.get('solar_exposure', status.get('solar_intensity', 0.5)), 0.5))
+
+    terrain_difficulty = _clamp(_as_float(status.get('terrain_difficulty', 0.3), 0.3))
+    comm_quality = _clamp(_as_float(status.get('comm_quality', 0.8), 0.8))
+    thermal_stress = _clamp(_as_float(status.get('thermal_stress', 0.3), 0.3))
+
+    capabilities = get_rover_capabilities(rover_id)
+    required_caps = set(task_request.get('required_capabilities', []))
+    capability_match = required_caps.issubset(capabilities)
+
+    context = {
+        'battery': battery,
+        'solar_intensity': solar,
+        'terrain_difficulty': terrain_difficulty,
+        'comm_quality': comm_quality,
+        'thermal_stress': thermal_stress,
+        'capability_match': capability_match,
+    }
+    predicted_risk, risk_breakdown = compute_fault_probability(
+        catalog,
+        task_request['task_type'],
+        task_request['difficulty_level'],
+        context,
+    )
+
+    distance_margin = _distance_margin(task_request.get('target_site'), status.get('position'))
+    accessibility_margin = 1.0 - terrain_difficulty
+
+    score_breakdown = {
+        'capability_match': 1.0 if capability_match else 0.0,
+        'battery_margin': battery,
+        'solar_margin': solar,
+        'thermal_margin': 1.0 - thermal_stress,
+        'comm_margin': comm_quality,
+        'distance_margin': distance_margin,
+        'accessibility_margin': accessibility_margin,
+        'risk_margin': 1.0 - (predicted_risk / 0.6),
+    }
+
+    weighted_score = (
+        score_breakdown['capability_match'] * 0.28
+        + score_breakdown['battery_margin'] * 0.20
+        + score_breakdown['solar_margin'] * 0.12
+        + score_breakdown['thermal_margin'] * 0.10
+        + score_breakdown['comm_margin'] * 0.10
+        + ((score_breakdown['distance_margin'] + score_breakdown['accessibility_margin']) / 2.0) * 0.10
+        + score_breakdown['risk_margin'] * 0.10
+    )
+
+    difficulty_cfg = catalog['difficulty_levels'][task_request['difficulty_level']]
+    min_battery = _as_float(difficulty_cfg.get('min_battery', 0.0), 0.0)
+
+    reject_reasons = []
+    if state != 'IDLE':
+        reject_reasons.append(f'state={state}')
+    if battery < min_battery:
+        reject_reasons.append(f'battery<{min_battery:.2f}')
+    if not capability_match:
+        reject_reasons.append('capability_mismatch')
+    if predicted_risk > 0.45:
+        reject_reasons.append('predicted_risk_too_high')
+
+    feasible = not reject_reasons
+
+    return {
+        'rover_id': rover_id,
+        'feasible': feasible,
+        'reject_reasons': reject_reasons,
+        'score': round(weighted_score, 4),
+        'score_breakdown': {k: round(v, 4) for k, v in score_breakdown.items()},
+        'predicted_fault_probability': round(predicted_risk, 4),
+        'risk_breakdown': risk_breakdown,
+        'capabilities': sorted(capabilities),
+    }
+
+
+def select_best_rover(catalog, fleet_registry, task_request):
+    scored = []
+    for rover_id, status in fleet_registry.items():
+        scored.append(score_rover_for_task(catalog, rover_id, status, task_request))
+
+    feasible = [item for item in scored if item['feasible']]
+    if not feasible:
+        scored_sorted = sorted(scored, key=lambda item: item['score'], reverse=True)
+        top = scored_sorted[0] if scored_sorted else None
+        reject_reason = 'no_rover_passed_feasibility_threshold'
+        if top and top['reject_reasons']:
+            reject_reason = ','.join(top['reject_reasons'])
+        return {
+            'selected_rover': None,
+            'reject_reason': reject_reason,
+            'scored_candidates': scored_sorted,
+        }
+
+    feasible_sorted = sorted(feasible, key=lambda item: item['score'], reverse=True)
+    return {
+        'selected_rover': feasible_sorted[0]['rover_id'],
+        'reject_reason': None,
+        'scored_candidates': feasible_sorted,
+    }

--- a/lunar_ops/rover_ws/src/rover_core/setup.py
+++ b/lunar_ops/rover_ws/src/rover_core/setup.py
@@ -17,6 +17,10 @@ setup(
             glob('launch/*.py')),
     ],
     install_requires=['setuptools'],
+    include_package_data=True,
+    package_data={
+        package_name: ['chandrayaan_task_catalog.json'],
+    },
     zip_safe=True,
     maintainer='TODO',
     maintainer_email='user@todo.todo',

--- a/web-sim/assets/chandrayaan_task_catalog.json
+++ b/web-sim/assets/chandrayaan_task_catalog.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": "2.0.0",
+  "catalog_name": "chandrayaan_swarm_task_catalog",
+  "difficulty_levels": {
+    "L1": {
+      "base_fault_rate": 0.01,
+      "duration_multiplier": 0.7,
+      "min_battery": 0.12,
+      "energy_drain_per_step": 0.002
+    },
+    "L2": {
+      "base_fault_rate": 0.03,
+      "duration_multiplier": 0.9,
+      "min_battery": 0.18,
+      "energy_drain_per_step": 0.003
+    },
+    "L3": {
+      "base_fault_rate": 0.06,
+      "duration_multiplier": 1.1,
+      "min_battery": 0.25,
+      "energy_drain_per_step": 0.004
+    },
+    "L4": {
+      "base_fault_rate": 0.1,
+      "duration_multiplier": 1.35,
+      "min_battery": 0.32,
+      "energy_drain_per_step": 0.0055
+    },
+    "L5": {
+      "base_fault_rate": 0.18,
+      "duration_multiplier": 1.7,
+      "min_battery": 0.42,
+      "energy_drain_per_step": 0.007
+    }
+  },
+  "task_types": {
+    "movement": {
+      "display_name": "Movement/Traverse",
+      "mission_phase": "CY3-ops",
+      "required_capabilities": ["mobility"],
+      "base_steps": 8,
+      "min_steps": 4,
+      "max_steps": 30,
+      "terrain_sensitivity": 1.0,
+      "solar_sensitivity": 0.7,
+      "comm_sensitivity": 0.5,
+      "thermal_sensitivity": 0.6,
+      "battery_sensitivity": 0.9,
+      "terrain_duration_sensitivity": 0.45,
+      "risk_floor": 0.005
+    },
+    "science": {
+      "display_name": "Science Investigation",
+      "mission_phase": "CY3-ops",
+      "required_capabilities": ["science", "imaging"],
+      "base_steps": 10,
+      "min_steps": 5,
+      "max_steps": 36,
+      "terrain_sensitivity": 0.5,
+      "solar_sensitivity": 0.6,
+      "comm_sensitivity": 0.7,
+      "thermal_sensitivity": 0.8,
+      "battery_sensitivity": 0.7,
+      "terrain_duration_sensitivity": 0.25,
+      "risk_floor": 0.008
+    },
+    "digging": {
+      "display_name": "Digging/Drilling/Excavation",
+      "mission_phase": "LUPEX-prospecting",
+      "required_capabilities": ["excavation"],
+      "base_steps": 12,
+      "min_steps": 6,
+      "max_steps": 42,
+      "terrain_sensitivity": 0.8,
+      "solar_sensitivity": 0.5,
+      "comm_sensitivity": 0.4,
+      "thermal_sensitivity": 0.9,
+      "battery_sensitivity": 1.0,
+      "terrain_duration_sensitivity": 0.35,
+      "risk_floor": 0.01
+    },
+    "pushing": {
+      "display_name": "Pushing/Transport/Regolith Handling",
+      "mission_phase": "base-build",
+      "required_capabilities": ["manipulation", "mobility"],
+      "base_steps": 11,
+      "min_steps": 6,
+      "max_steps": 40,
+      "terrain_sensitivity": 0.9,
+      "solar_sensitivity": 0.4,
+      "comm_sensitivity": 0.4,
+      "thermal_sensitivity": 0.7,
+      "battery_sensitivity": 1.0,
+      "terrain_duration_sensitivity": 0.4,
+      "risk_floor": 0.01
+    },
+    "photo": {
+      "display_name": "Photo/Imaging/Survey",
+      "mission_phase": "CY3-ops",
+      "required_capabilities": ["imaging"],
+      "base_steps": 6,
+      "min_steps": 3,
+      "max_steps": 24,
+      "terrain_sensitivity": 0.3,
+      "solar_sensitivity": 0.5,
+      "comm_sensitivity": 0.8,
+      "thermal_sensitivity": 0.4,
+      "battery_sensitivity": 0.4,
+      "terrain_duration_sensitivity": 0.15,
+      "risk_floor": 0.004
+    },
+    "sample-handling": {
+      "display_name": "Sample Handling/Transfer",
+      "mission_phase": "CY4-sample-chain",
+      "required_capabilities": ["sample-logistics", "manipulation"],
+      "base_steps": 9,
+      "min_steps": 5,
+      "max_steps": 32,
+      "terrain_sensitivity": 0.6,
+      "solar_sensitivity": 0.5,
+      "comm_sensitivity": 0.6,
+      "thermal_sensitivity": 0.8,
+      "battery_sensitivity": 0.8,
+      "terrain_duration_sensitivity": 0.3,
+      "risk_floor": 0.009
+    }
+  }
+}

--- a/web-sim/index.html
+++ b/web-sim/index.html
@@ -316,9 +316,30 @@
               type="text"
               id="task-id-input"
               class="input-field"
-              placeholder="e.g. SAMPLE-001"
-              value="SAMPLE-001"
+              placeholder="e.g. CY3-SCI-001"
+              value="CY3-SCI-001"
             />
+          </div>
+          <div class="input-group">
+            <label for="task-type-select">Task Type</label>
+            <select id="task-type-select" class="input-field select-field">
+              <option value="movement">Movement/Traverse</option>
+              <option value="science">Science Investigation</option>
+              <option value="digging">Digging/Drilling</option>
+              <option value="pushing">Pushing/Regolith Handling</option>
+              <option value="photo">Photo/Imaging Survey</option>
+              <option value="sample-handling">Sample Handling/Transfer</option>
+            </select>
+          </div>
+          <div class="input-group">
+            <label for="task-difficulty-select">Difficulty</label>
+            <select id="task-difficulty-select" class="input-field select-field">
+              <option value="L1">L1 - Very Easy</option>
+              <option value="L2" selected>L2 - Easy</option>
+              <option value="L3">L3 - Moderate</option>
+              <option value="L4">L4 - Hard</option>
+              <option value="L5">L5 - Extreme</option>
+            </select>
           </div>
         </div>
 
@@ -372,17 +393,17 @@
           </div>
           <div class="input-group">
             <label for="fault-slider"
-              >Fault Probability
-              <span class="param-value" id="fault-prob-value">10%</span></label
+              >Risk Bias
+              <span class="param-value" id="fault-prob-value">0%</span></label
             >
             <input
               type="range"
               id="fault-slider"
               class="range-input"
-              min="0"
-              max="100"
+              min="-20"
+              max="20"
               step="1"
-              value="10"
+              value="0"
             />
           </div>
         </div>


### PR DESCRIPTION
## Problem
Runtime behavior used generic tasks with fixed 10-step execution and flat fault probability. Assignment logic did not include capability classes, context-aware risk, or explainable scoring.

## What changed
### Shared task system
- Added machine-readable task catalogs:
  - `web-sim/assets/chandrayaan_task_catalog.json`
  - `lunar_ops/rover_ws/src/rover_core/rover_core/chandrayaan_task_catalog.json`
- Added reusable task modeling engine:
  - `lunar_ops/rover_ws/src/rover_core/rover_core/task_model.py`

### ROS runtime updates
- `earth_node.py`
  - context-aware assignment via capability/risk scoring
  - structured `START_TASK` payload support (`task_type`, `difficulty_level`, etc.)
  - assignment explanation in command payload and logs
- `rover_node.py`
  - variable duration by task+difficulty
  - dynamic per-step fault probability from context
  - expanded telemetry fields for mission observability
- `setup.py`
  - packaged task catalog data for ROS package use

### Web simulation updates
- `web-sim/simulation.js`
  - browser-side task normalization, duration/risk model, and scoring logic
  - structured command payload support
  - expanded telemetry fields
- `web-sim/app.js` + `web-sim/index.html`
  - task type selector
  - difficulty selector (L1..L5)
  - auto-assignment using explainable scoring
  - risk metadata shown in telemetry/command log

### Tests
- Reworked `test_task_assignment.py` for v2 behavior:
  - catalog validation
  - L1 vs L5 behavior
  - context modifier effects
  - capability-aware rover selection
  - rejection behavior
  - legacy fallback behavior

## Why this design
A shared catalog plus deterministic scoring utilities makes ROS and web simulation behavior converge around the same mission semantics, while keeping policy (catalog JSON) separate from engine logic.

## Testing evidence
- `pytest -q lunar_ops/rover_ws/src/rover_core/test`
- `node --check web-sim/simulation.js`
- `node --check web-sim/app.js`

## Migration notes
- Legacy `START_TASK` still works with only `task_id`, defaulting to `movement/L2`.
- New UI defaults expose task type and difficulty explicitly.

## Superseded issue mapping (old -> new)
- generic fixed fault/step behavior -> `#39`, `#40`, `#42`
- simple battery-only auto assignment -> `#41`
- missing task controls -> `#43`
- missing observability schema -> `#44`
