### PR TITLE
docs: migrate project narrative and workflow to chandrayaan v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# LSOAS CI Pipeline — runs on every PR to main
+# LSOAS CI Pipeline — runs on PRs/pushes to main and develop
 # ─────────────────────────────────────────────────────────────────────────────
 name: CI — Lint, Build & Health Checks
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   push:
-    branches: [main]
+    branches: [main, develop]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -4,393 +4,230 @@
   <img src="https://img.shields.io/badge/Three.js-WebGL-black?style=for-the-badge&logo=threedotjs" alt="Three.js" />
   <img src="https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge" alt="License" />
   <img src="https://img.shields.io/badge/Platform-Web%20%7C%20Docker-orange?style=for-the-badge&logo=docker" alt="Platform" />
-  <br/>
-  <a href="https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/actions">
-    <img src="https://img.shields.io/github/actions/workflow/status/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/ci.yml?style=for-the-badge&label=CI&logo=githubactions&logoColor=white" alt="CI" />
-  </a>
-  <a href="https://github.com/users/SumanthVarma798/projects/6">
-    <img src="https://img.shields.io/badge/Project%20Board-Kanban-purple?style=for-the-badge&logo=github" alt="Project Board" />
-  </a>
 </p>
 
-<h1 align="center">🌙 LSOAS</h1>
+<h1 align="center">LSOAS</h1>
 <h3 align="center">Lunar Surface Operations Autonomous Science Network</h3>
 
 <p align="center">
-  <strong>From a single rover to a fully autonomous lunar fleet.</strong><br/>
-  <em>Mission control. Multi-rover orchestration. 3D lunar visualization.<br/>
-  AI-driven science campaigns — all in your browser.</em>
+  <strong>Chandrayaan-focused multi-rover mission control and simulation stack.</strong><br/>
+  <em>Context-aware task assignment, dynamic fault modeling, and lunar operations telemetry.</em>
 </p>
 
 ---
 
-> **🚀 This project is under active development.** What started as a single-rover command prototype is evolving into a full-scale, multi-asset space mission control system. Follow the [roadmap](#-roadmap--whats-coming) to see where we're headed.
+## Project Focus (Chandrayaan v2)
+
+The project is now redesigned around a Chandrayaan-themed future mission concept:
+
+- Real mission basis from Chandrayaan-3 rover operations, Chandrayaan-4 sample chain direction, and LUPEX polar prospecting goals.
+- Future extension to an Indian lunar-base predeploy and construction swarm.
+- Task-centric rover operations instead of generic flat tasks.
+
+### Reality Basis
+
+Real mission references:
+
+- [ISRO Chandrayaan-3 details](https://www.isro.gov.in/Chandrayaan3_Details.html)
+- [ISRO Chandrayaan-3 updates (Pragyan payload operations)](https://www.isro.gov.in/Ch3_Details.html)
+- [ISRO Chandrayaan-4 approval and mission objectives](https://www.isro.gov.in/UnionCabinetapprovesChandrayaan4mission.html)
+- [JAXA LUPEX mission overview](https://global.jaxa.jp/projects/sas/lupex/)
+
+Future extrapolation in this repo:
+
+- Multi-purpose rover swarm for base predeploy and base-build logistics.
+- Pushing/regolith handling and sample transfer workflows at larger operational scale.
 
 ---
 
-## 🖥️ Live Dashboard — What We've Built So Far
+## Task Taxonomy and Difficulty Model
 
-A NASA-inspired fleet dashboard simulating Earth↔Moon communication with realistic latency, packet loss, and fault-tolerant command protocols across multiple rovers. No Docker or ROS required — just open it in your browser.
+### Task Families
 
-### Dashboard States
+1. `movement` - traverse/navigation
+2. `science` - in-situ investigation and instrument runs
+3. `digging` - excavation/drilling
+4. `pushing` - regolith handling/transport
+5. `photo` - imaging/survey
+6. `sample-handling` - transfer/handling pipeline
 
-<table>
-<tr>
-<td><strong>Idle — Awaiting Commands</strong></td>
-<td><strong>Executing — Task In Progress</strong></td>
-</tr>
-<tr>
-<td><img src="docs/screenshots/dashboard-idle.png" alt="Dashboard Idle" width="400"/></td>
-<td><img src="docs/screenshots/dashboard-executing.png" alt="Dashboard Executing" width="400"/></td>
-</tr>
-<tr>
-<td><strong>Safe Mode — Fault Detected</strong></td>
-<td><strong>Light Theme</strong></td>
-</tr>
-<tr>
-<td><img src="docs/screenshots/dashboard-safe-mode.png" alt="Dashboard Safe Mode" width="400"/></td>
-<td><img src="docs/screenshots/dashboard-light-theme.png" alt="Dashboard Light Theme" width="400"/></td>
-</tr>
-</table>
+### Difficulty Levels
 
----
+| Level | Base Fault Rate |
+| --- | --- |
+| `L1` | `1%` |
+| `L2` | `3%` |
+| `L3` | `6%` |
+| `L4` | `10%` |
+| `L5` | `18%` |
 
-## 🗺️ Roadmap — What's Coming
+Final predicted fault probability is context-aware and clamped to `0%..60%` using:
 
-This isn't just a dashboard. We're building a **full mission operations system** — incrementally, phase by phase. Each phase adds a new layer of realism, complexity, and genuine aerospace engineering.
+- battery SOC
+- lunar day/night state
+- solar intensity
+- terrain difficulty
+- comm quality
+- thermal stress
+- capability match
 
-<table>
-<tr>
-<th>Phase</th>
-<th>Focus</th>
-<th>Key Deliverables</th>
-<th>Status</th>
-</tr>
-<tr>
-<td>🟢 <strong>Phase 1</strong></td>
-<td><strong>Multi-Rover Constellation</strong></td>
-<td>3-5 simultaneous rovers • Fleet manager • Auto task assignment • 3D lunar surface with real NASA textures • Fleet status grid</td>
-<td>🚧 In Progress</td>
-</tr>
-<tr>
-<td>⚪ <strong>Phase 2</strong></td>
-<td><strong>Resource Management</strong></td>
-<td>Solar power simulation • Thermal management • Comm bandwidth budgets • Consumable tracking</td>
-<td>Planned</td>
-</tr>
-<tr>
-<td>⚪ <strong>Phase 3</strong></td>
-<td><strong>Ground Station Network</strong></td>
-<td>DSN-inspired multi-station coverage • Earth-rotation scheduling • Handoff logic • 3D globe visualization</td>
-<td>Planned</td>
-</tr>
-<tr>
-<td>⚪ <strong>Phase 4</strong></td>
-<td><strong>Autonomous Mission Planning</strong></td>
-<td>24-hour command sequences • Conditional logic • Gantt timeline editor • Autonomous replanning</td>
-<td>Planned</td>
-</tr>
-<tr>
-<td>⚪ <strong>Phase 5</strong></td>
-<td><strong>Advanced Fleet Coordination & AI</strong></td>
-<td>Swarm navigation • Collision avoidance • Inter-rover mesh network • RL path planning • Anomaly detection</td>
-<td>Planned</td>
-</tr>
-</table>
+Task catalog source (machine-readable):
 
-> 📋 **Full task breakdown**: See the [LSOAS Mission Roadmap](https://github.com/users/SumanthVarma798/projects/6) on GitHub Projects — 20+ issues across 5 milestones.
+- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/web-sim/assets/chandrayaan_task_catalog.json`
+- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/lunar_ops/rover_ws/src/rover_core/rover_core/chandrayaan_task_catalog.json`
 
 ---
 
-## 🌍 Phase 1 Highlights — What's Being Built Now
+## Architecture Snapshot
 
-### 🤖 Multi-Rover Fleet Operations
+Core runtime nodes/layers:
 
-Transform the single-rover system into a **fleet of 3-5 autonomous rovers**, each with unique IDs, independent state machines, and telemetry streams. A centralized **Fleet Manager** node will orchestrate task assignment based on battery levels, solar exposure, and operational state.
+- `EarthNode` (`earth_node.py`): context-aware assignment engine with score breakdown and deterministic rejection.
+- `RoverNode` (`rover_node.py`): variable-duration task execution and dynamic risk/fault behavior.
+- `SpaceLinkNode` (`space_link_node.py`): latency/jitter/drop relay model.
+- `web-sim/simulation.js`: browser-side parity model with same task taxonomy and risk strategy.
 
-```
-┌───────────┐     ┌─────────────┐     ┌──────────┐  ┌──────────┐  ┌──────────┐
-│   EARTH   │────▶│ SPACE LINK  │────▶│ ROVER-1  │  │ ROVER-2  │  │ ROVER-3  │
-│  STATION  │◀────│   (RELAY)   │◀────│  (IDLE)  │  │(EXECUTING│  │  (SAFE)  │
-└───────────┘     └─────────────┘     └──────────┘  └──────────┘  └──────────┘
-      │                                     ▲              ▲             ▲
-      │           ┌─────────────┐           │              │             │
-      └──────────▶│   FLEET     │───────────┴──────────────┴─────────────┘
-                  │  MANAGER    │   Tracks all rover states, auto-assigns tasks
-                  └─────────────┘
-```
+Task-model utility module:
 
-### 🌙 3D Lunar Surface Visualization
+- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/lunar_ops/rover_ws/src/rover_core/rover_core/task_model.py`
 
-An interactive **Three.js-powered 3D Moon** using real NASA surface textures from the Lunar Reconnaissance Orbiter. Rovers appear as markers on the surface, relay satellites orbit with visible communication beams, and you can rotate, zoom, and click to control the mission.
+Supporting docs:
 
-| Data Source                                                                          | Usage                             |
-| ------------------------------------------------------------------------------------ | --------------------------------- |
-| [NASA CGI Moon Kit](https://svs.gsfc.nasa.gov/4720)                                  | High-res color map + displacement |
-| [LRO WAC Global Mosaic](https://wms.lroc.asu.edu/lroc/global_product/100_mpp_warped) | 100m/px surface texture           |
-| [LOLA Elevation Data](https://pgda.gsfc.nasa.gov/products/54)                        | Terrain displacement mapping      |
-
-### 📊 Fleet Dashboard
-
-A responsive status grid replacing the single-rover view:
-
-```
-┌─────────────────────────────────────────────────────┐
-│  🤖 Fleet: 3 active │ Avg Battery: 68% │ 2 IDLE    │
-├─────────┬─────────┬─────────────────────────────────┤
-│ ROVER-1 │ ROVER-2 │ ROVER-3                         │
-│  IDLE   │EXECUTING│  SAFE_MODE                      │
-│ 🔋 87%  │ 🔋 45%  │ 🔋 23%                          │
-│ ☀️ Sun  │ 🌑 Dark │ ☀️ Sun                          │
-└─────────┴─────────┴─────────────────────────────────┘
-```
+- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/docs/chandrayaan_v2_architecture.md`
+- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/docs/chandrayaan_v2_migration.md`
 
 ---
 
-## 🏗️ Current Architecture
+## Quick Start
 
-```
-┌────────────────────────────────────────────────────────────────────────────┐
-│                            MISSION CONTROL                                 │
-│                                                                            │
-│  ┌──────────────┐     ┌──────────────┐     ┌───────────────────────────┐   │
-│  │ EARTH STATION│────▶│  SPACE LINK  │────▶│  ROVER FLEET (N = 3..5+)  │   │
-│  │ (COMMAND UI) │◀────│   (RELAY)    │◀────│  R1  R2  R3  R4  R5 ...   │   │
-│  └──────────────┘     └──────────────┘     └───────────────────────────┘   │
-│         │                        │                         │                │
-│         │                        │                         │                │
-│         │                ACK + TELEMETRY STREAMS           │                │
-│         │                        ▼                         │                │
-│         │              ┌────────────────────┐              │                │
-│         └─────────────▶│ TELEMETRY MONITOR  │◀─────────────┘                │
-│                        │ + FLEET STATUS GRID│                               │
-│                        └────────────────────┘                               │
-└────────────────────────────────────────────────────────────────────────────┘
-```
-
-| Node / Layer             | Role                         | Key Behaviors                                                                 |
-| ------------------------ | ---------------------------- | ----------------------------------------------------------------------------- |
-| **🌍 Earth Station**     | Ground command interface     | Fleet-aware dispatch, ACK tracking, auto/manual target selection             |
-| **📡 Space Link**        | Moon↔Earth relay             | Configurable latency/jitter/drop simulation                                  |
-| **🤖 Rover Fleet**       | Autonomous rover constellation | Per-rover state machine (IDLE→EXECUTING→SAFE_MODE→ERROR), battery/task state |
-| **📊 Telemetry Monitor** | Fleet telemetry visualization | Per-rover feed aggregation, fleet summary banner, command/ACK counters       |
-
-### Rover State Machine
-
-```
-            START_TASK
-  ┌──────┐ ──────────▶ ┌───────────┐
-  │ IDLE │              │ EXECUTING │
-  └──┬───┘ ◀────────── └─────┬─────┘
-     │       task done       │
-     │                  fault detected
-     │ RESET                 │
-     │       ┌───────────┐   │
-     └────── │ SAFE_MODE │ ◀─┘
-             └─────┬─────┘
-                   │ unrecoverable
-             ┌─────▼─────┐
-             │   ERROR   │
-             └───────────┘
-```
-
----
-
-## 🚀 Quick Start
-
-### Option 1: Web Simulation (Recommended)
-
-No dependencies — just a browser and Python.
+### Web Simulation
 
 ```bash
-# Clone
 git clone https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network.git
-cd Lunar-Surface-Operations-Autonomous-Science-Network
-
-# Launch
-cd web-sim && python3 -m http.server 8080
+cd Lunar-Surface-Operations-Autonomous-Science-Network/web-sim
+python3 -m http.server 8080
 ```
 
-Open **http://localhost:8080** and start sending commands! 🎉
+Open: `http://localhost:8080`
 
-Fleet presets:
+Useful query params:
 
-- Default 3-rover run: `http://localhost:8080`
-- 5-rover load profile: `http://localhost:8080/?rovers=5`
-- Light theme preview: `http://localhost:8080/?theme=light`
+- `?rovers=5`
+- `?scenario=basic-auto&task=CY3-SCI-001&task_type=science&difficulty=L3`
+- `?scenario=safe-mode&task=CY4-SAMPLE-008&task_type=sample-handling&difficulty=L4`
 
-#### Keyboard Shortcuts
-
-| Key         | Command    |
-| ----------- | ---------- |
-| `S`         | Start Task |
-| `A`         | Abort      |
-| `Shift + S` | Safe Mode  |
-| `R`         | Reset      |
-
-#### Configurable Parameters
-
-| Parameter         | Default | Range      | Description                |
-| ----------------- | ------- | ---------- | -------------------------- |
-| Base Latency      | 1.3s    | 0.1 – 5.0s | One-way signal travel time |
-| Jitter            | ±0.2s   | 0 – 1.0s   | Random delay variation     |
-| Drop Rate         | 5%      | 0 – 50%    | Packet loss probability    |
-| Fault Probability | 10%     | 0 – 100%   | Fault chance per task step |
-
-#### Fleet Command Routing
-
-Use **Target Rover** in the command panel:
-
-- `Auto-Select (Best Rover)`: routes based on live fleet conditions.
-- `Rover-n`: manual override to target a specific rover.
-
-Routing behavior in auto mode:
-
-- `START_TASK`: prefers highest-score `IDLE` rover.
-- `ABORT`: prefers currently executing rover with highest progress.
-- `GO_SAFE`: prefers active executing rover; falls back to highest-score rover.
-- `RESET`: prefers lowest-battery rover currently in `SAFE_MODE`.
-
-Reference manual test report: `docs/phase1_testing_results.md`
-
-### Option 2: ROS 2 Simulation (Full Setup)
-
-Requires Docker and ROS 2 Humble.
+### ROS 2 Simulation
 
 ```bash
-make build                # Build ROS workspace in Docker
-
-# Launch in separate terminals:
-make test-space-link      # Terminal 1: Space Link relay
-make test-telemetry       # Terminal 2: Telemetry monitor
-make test-rover           # Terminal 3: Rover node
-make test-earth           # Terminal 4: Earth station (interactive)
+cd /Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network
+make build
+make test-space-link
+make test-telemetry
+make test-rover
+make test-earth
 ```
 
 ---
 
-## 📁 Project Structure
+## Command Payload (START_TASK)
 
-```
-Lunar-Surface-Operations-Autonomous-Science-Network/
-│
-├── web-sim/                          # 🌐 Browser-based simulation
-│   ├── index.html                    #    Dashboard layout
-│   ├── index.css                     #    Design system (dark/light themes)
-│   ├── simulation.js                 #    Simulation engine (4 nodes in JS)
-│   └── app.js                        #    UI controller & DOM bindings
-│
-├── lunar_ops/                        # 🤖 ROS 2 implementation
-│   ├── docs/                         #    Concept & test documentation
-│   └── rover_ws/src/rover_core/      #    ROS package
-│       └── rover_core/
-│           ├── rover_node.py         #    Rover state machine
-│           ├── earth_node.py         #    Earth command interface
-│           ├── space_link_node.py    #    Communication relay
-│           └── telemetry_monitor.py  #    Telemetry display
-│
-├── .agent/workflows/                 # 🤖 Agent workflows
-│   ├── implement-issue.md            #    /implement-issue — build a feature
-│   ├── explain-issue.md              #    /explain-issue — break down a task
-│   └── compare-issues.md             #    /compare-issues — side-by-side analysis
-│
-├── .github/
-│   ├── workflows/ci.yml             #    CI pipeline (lint, build, tests, health)
-│   └── scripts/                      #    Project automation scripts
-│
-├── scripts/rosdev.sh                 #    Docker dev environment helper
-├── Makefile                          #    Build & run automation
-└── .gitignore
-```
+`START_TASK` now supports structured mission fields:
+
+- `task_id`
+- `task_type`
+- `difficulty_level`
+- `required_capabilities`
+- `mission_phase`
+- `target_site` (optional)
+- `assignment_score_breakdown`
+- `predicted_fault_probability`
+
+Legacy `START_TASK` with only `task_id` still works and defaults to:
+
+- `task_type=movement`
+- `difficulty_level=L2`
 
 ---
 
-## 🔧 Development Workflow
+## Telemetry Additions
 
-### Branch-Based Development
+Telemetry and fleet status now include:
+
+- `active_task_type`
+- `active_task_difficulty`
+- `task_total_steps`
+- `predicted_fault_probability`
+- `assignment_score_breakdown`
+- `lunar_time_state`
+- `solar_intensity`
+- `terrain_difficulty`
+- `comm_quality`
+- `thermal_stress`
+
+---
+
+## Development Workflow (main + develop)
+
+Use this branch flow for all feature work:
 
 ```bash
-git checkout main && git pull origin main     # Start from latest
-git checkout -b feature/your-feature-name     # Create feature branch
-# ... make changes ...
-git commit -m "feat: description"             # Conventional commits
-git push -u origin feature/your-feature-name  # Push & open PR
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+git checkout -B develop origin/main
+git push -u origin develop
+
+# feature branch from develop
+git checkout -b codex/your-feature-name develop
+# ... commits ...
+git push -u origin codex/your-feature-name
+# open PR -> develop
+# after integration: open release PR develop -> main
 ```
 
-### CI Pipeline
-
-Every PR to `main` automatically runs:
-
-| Check               | What it validates                                          |
-| ------------------- | ---------------------------------------------------------- |
-| 🐍 **Python Lint**  | Flake8 on all ROS nodes                                    |
-| 🤖 **ROS 2 Build**  | Full `colcon build` in `ros:humble` container              |
-| 🧪 **Python Tests** | Auto-discovers and runs `test_*.py` with pytest            |
-| 🌐 **Web Health**   | HTML structure, JS syntax, CSS validation, HTTP smoke test |
-| 📋 **Repo Health**  | Required files, large file detection, secret scanning      |
-
-### Commit Convention
-
-| Prefix      | Usage              |
-| ----------- | ------------------ |
-| `feat:`     | New feature        |
-| `fix:`      | Bug fix            |
-| `chore:`    | Maintenance        |
-| `docs:`     | Documentation      |
-| `refactor:` | Code restructuring |
-| `ci:`       | CI/CD changes      |
+CI triggers on `main` and `pull_request` to `main`.
 
 ---
 
-## 🧪 Testing Scenarios
+## Chandrayaan v2 Roadmap Issues
 
-| Scenario                  | Steps                                                          | What to Observe                                            |
-| ------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Basic auto assignment** | Auto target → START TASK                                       | Exactly one rover enters `EXECUTING`, ACK resolves         |
-| **Manual selection**      | Select `Rover-2` → START TASK                                  | Command routes only to selected rover                      |
-| **Safe mode handling**    | START TASK → GO SAFE                                           | Rover transitions to `SAFE_MODE` and fleet counts update   |
-| **Battery priority**      | Set uneven batteries → Auto START TASK                         | Highest-battery eligible rover receives task               |
-| **5-rover load**          | Open `?rovers=5` and observe ~20s                              | Stable telemetry feed from rover-1..rover-5 at 0.5 Hz each |
-| **Network stress**        | Increase Drop/Latency sliders and dispatch commands            | Retries, delayed ACKs, and drop indicators in logs         |
+Active redesigned roadmap:
 
----
-
-## 🎨 Design Philosophy
-
-- **Dark-first** — Deep space-black with high-contrast elements
-- **Frosted glass** — `backdrop-filter: blur()` panels for depth
-- **Typography** — SF Pro / Inter with careful hierarchy
-- **Color semantics** — Green (nominal), Yellow (warning), Red (error), Blue (executing)
-- **Micro-animations** — Smooth transitions on state changes
-- **Information density** — All critical data visible at a glance
+- [#38 Epic: Chandrayaan v2 context-aware orchestration](https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/issues/38)
+- [#39 TaskCatalog schema and loader](https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/issues/39)
+- [#40 Dynamic fault-rate engine](https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/issues/40)
+- [#41 Capability-class assignment output](https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/issues/41)
+- [#42 Variable-duration execution engine](https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/issues/42)
+- [#43 Web task controls](https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/issues/43)
+- [#44 Expanded telemetry schema](https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/issues/44)
+- [#45 Validation suite](https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/issues/45)
+- [#46 Docs and migration](https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/issues/46)
 
 ---
 
-## 🔮 The Full Vision
+## Testing
 
-When complete, LSOAS will simulate a **realistic multi-asset lunar mission** — the kind of system NASA JPL builds for real missions like Mars 2020 and Artemis. The full system will include:
+Run core unit/integration tests:
 
-- **Fleet of autonomous rovers** navigating the lunar surface with independent AI
-- **3D interactive globe** with real NASA LRO textures and orbital mechanics
-- **Deep Space Network simulation** with realistic coverage windows and antenna scheduling
-- **Autonomous mission planning** with conditional command sequences and replanning
-- **Swarm coordination** with formation flying, collision avoidance, and mesh networking
-- **Machine learning** for path planning, anomaly detection, and science prioritization
+```bash
+pytest -q /Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/lunar_ops/rover_ws/src/rover_core/test
+```
 
-This is a learning project with professional aspirations — every system mirrors real aerospace engineering patterns.
+Expected coverage targets for v2 scope:
+
+- Task catalog validation
+- L1..L5 behavior differences
+- Context modifier influence on risk
+- Capability-aware assignment selection
+- Deterministic rejection when infeasible
+- Legacy command fallback behavior
+
+Detailed testing guide:
+
+- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/docs/chandrayaan_v2_testing.md`
 
 ---
 
-## 📄 License
+## License
 
 MIT
-
----
-
-<p align="center">
-  <em>Built for learning. Engineered like the real thing.</em><br/>
-  <strong>🌙 LSOAS — Lunar Surface Operations Autonomous Science Network</strong><br/><br/>
-  <a href="https://github.com/users/SumanthVarma798/projects/6">📋 Project Board</a> •
-  <a href="https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/milestones">🏁 Milestones</a> •
-  <a href="https://github.com/SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network/issues">📝 Issues</a>
-</p>

--- a/docs/chandrayaan_v2_architecture.md
+++ b/docs/chandrayaan_v2_architecture.md
@@ -1,0 +1,78 @@
+# Chandrayaan v2 Architecture
+
+## Objective
+
+Replace generic fleet tasking with a context-aware rover-task model aligned to Chandrayaan-inspired mission operations.
+
+## Core Components
+
+1. `task_model.py`
+- Loads and validates TaskCatalog.
+- Normalizes task requests.
+- Computes task duration and predicted fault probability.
+- Scores rover feasibility and assignment ranking.
+
+2. `earth_node.py`
+- Accepts structured task requests (`task_type`, `difficulty_level`, mission metadata).
+- Runs explainable assignment scoring.
+- Dispatches `START_TASK` payloads with `assignment_score_breakdown` and predicted risk.
+
+3. `rover_node.py`
+- Executes variable-duration tasks based on catalog + context.
+- Updates risk dynamically each step.
+- Publishes expanded telemetry context.
+
+4. `web-sim/simulation.js`
+- Browser parity model of task and assignment logic.
+- Uses same task taxonomy/difficulty model as ROS path.
+
+## Task Families
+
+- `movement`
+- `science`
+- `digging`
+- `pushing`
+- `photo`
+- `sample-handling`
+
+## Difficulty and Risk
+
+Base fault rates:
+
+- `L1=1%`
+- `L2=3%`
+- `L3=6%`
+- `L4=10%`
+- `L5=18%`
+
+Dynamic modifiers:
+
+- battery SOC
+- lunar day/night state
+- solar intensity
+- terrain difficulty
+- comm quality
+- thermal stress
+- capability match
+
+Final risk clamp: `0..0.6`.
+
+## Assignment Output Contract
+
+- `selected_rover`
+- `reject_reason`
+- `score_breakdown`
+- `predicted_fault_probability`
+
+## Telemetry Additions
+
+- `active_task_type`
+- `active_task_difficulty`
+- `task_total_steps`
+- `predicted_fault_probability`
+- `assignment_score_breakdown`
+- `lunar_time_state`
+- `solar_intensity`
+- `terrain_difficulty`
+- `comm_quality`
+- `thermal_stress`

--- a/docs/chandrayaan_v2_migration.md
+++ b/docs/chandrayaan_v2_migration.md
@@ -1,0 +1,31 @@
+# Chandrayaan v2 Migration Notes
+
+## Superseded Legacy Issues
+
+Closed as superseded by new roadmap epic:
+
+- `#2`
+- `#16`
+- `#17`
+- `#18`
+- `#19`
+- `#20`
+
+Replacement roadmap starts at:
+
+- `#38` (epic) with child issues `#39` to `#46`.
+
+## Behavior Changes
+
+1. Generic fixed 10-step tasks replaced with catalog-driven durations.
+2. Flat fault probability replaced with context-aware risk model.
+3. Auto assignment now uses capability and risk thresholds.
+4. `START_TASK` payload extended with task metadata.
+5. Telemetry expanded for mission-context observability.
+
+## Backward Compatibility
+
+Legacy `START_TASK` payload with only `task_id` still works and defaults to:
+
+- `task_type=movement`
+- `difficulty_level=L2`

--- a/docs/chandrayaan_v2_testing.md
+++ b/docs/chandrayaan_v2_testing.md
@@ -1,0 +1,27 @@
+# Chandrayaan v2 Testing Guide
+
+## Automated Tests
+
+Run:
+
+```bash
+pytest -q lunar_ops/rover_ws/src/rover_core/test
+```
+
+## Required Scenarios
+
+1. TaskCatalog parsing and schema checks.
+2. Difficulty profile checks (L1 vs L5 duration and risk).
+3. Context modifier checks (low battery + night vs high battery + day).
+4. Capability-aware assignment checks (`science` vs `digging` candidate selection).
+5. Deterministic rejection when no rover is feasible.
+6. Legacy `START_TASK` fallback behavior.
+
+## Manual Web-Sim Smoke Checks
+
+1. Start web-sim.
+2. Set `Task Type=Science`, `Difficulty=L3`, run auto dispatch.
+3. Confirm command log shows type/difficulty and selected rover.
+4. Confirm telemetry feed shows risk percentage and task metadata.
+5. Raise `Risk Bias` and verify increased fault incidence.
+6. Try an extreme task (`sample-handling`, `L5`) with poor rover state and confirm rejection.


### PR DESCRIPTION
## Problem
Documentation and developer workflow did not reflect the Chandrayaan-v2 mission framing, task taxonomy, or `main -> develop` branch strategy. CI was also scoped only to `main` workflows.

## What changed
- Rewrote `README.md` around Chandrayaan-v2 mission context.
- Added explicit "Reality basis" vs future extrapolation split.
- Documented new task taxonomy, difficulty model, structured payloads, and telemetry schema.
- Added new docs:
  - `docs/chandrayaan_v2_architecture.md`
  - `docs/chandrayaan_v2_testing.md`
  - `docs/chandrayaan_v2_migration.md`
- Updated CI triggers in `.github/workflows/ci.yml` to run for both `main` and `develop`.

## Why this design
The runtime/model changes are substantial; docs need to be executable and aligned with branch/release process so future contributors can build and ship consistently.

## Testing evidence
- Markdown/docs sanity reviewed against new issue set (`#38`-`#46`).
- CI config change is syntactically minimal (`branches` list expansion).

## Migration notes
- Legacy generic roadmap issues are superseded by Chandrayaan-v2 issues.
- Team workflow now expects feature PRs into `develop`, then release PR `develop -> main`.

## Superseded issue mapping (old -> new)
- Legacy roadmap narrative (`#2`, `#17`, `#18`, `#19`, `#20`) -> `#38` + `#39..#46`
- Legacy docs/update issue (`#16`) -> `#46`
