### PR TITLE
release: v1.0.0 (Phase 1 complete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The project is now redesigned around a Chandrayaan-themed future mission concept
 - Real mission basis from Chandrayaan-3 rover operations, Chandrayaan-4 sample chain direction, and LUPEX polar prospecting goals.
 - Future extension to an Indian lunar-base predeploy and construction swarm.
 - Task-centric rover operations instead of generic flat tasks.
+- Teaching-oriented dashboard presets for Chandrayaan-3, Chandrayaan-4, LUPEX, and future base-build scenarios.
 
 ### Reality Basis
 
@@ -98,6 +99,44 @@ Supporting docs:
 
 ---
 
+## Dashboard Screenshots
+
+### Main Mission Dashboard States
+
+Idle operations
+
+![LSOAS dashboard idle state](docs/screenshots/dashboard-idle.png)
+
+Executing task flow
+
+![LSOAS dashboard executing task state](docs/screenshots/dashboard-executing.png)
+
+Safe mode command flow
+
+![LSOAS dashboard safe mode state](docs/screenshots/dashboard-safe-mode.png)
+
+### Mission Setup and Selection Flows
+
+Battery-informed rover selection
+
+![Battery-informed rover selection](docs/screenshots/phase1-battery-selection.png)
+
+Manual rover selection
+
+![Manual rover selection](docs/screenshots/phase1-manual-selection.png)
+
+Telemetry-first mission stream
+
+![Telemetry stream focus](docs/screenshots/phase1-telemetry-load.png)
+
+### Visual Theme Variant
+
+Light theme reference
+
+![Light theme dashboard view](docs/screenshots/dashboard-light-theme.png)
+
+---
+
 ## Quick Start
 
 ### Web Simulation
@@ -115,6 +154,10 @@ Useful query params:
 - `?rovers=5`
 - `?scenario=basic-auto&task=CY3-SCI-001&task_type=science&difficulty=L3`
 - `?scenario=safe-mode&task=CY4-SAMPLE-008&task_type=sample-handling&difficulty=L4`
+- `?mission=cy3-pragyan`
+- `?mission=cy4-sample-return&target_site=Sample%20Depot%20Alpha`
+
+Dashboard task IDs are auto-generated (mission + task type + difficulty + sequence), and can still be manually edited at any time.
 
 ### ROS 2 Simulation
 

--- a/web-sim/app.js
+++ b/web-sim/app.js
@@ -63,6 +63,7 @@
     if (open) {
       floatingPanel.setAttribute("aria-hidden", "false");
       document.body.classList.add("three-panel-open");
+      syncAccordionLayoutMode(true);
       if (panelTelemetry) panelTelemetry.classList.add("compact-log");
       updateFleetUi();
 
@@ -77,6 +78,7 @@
       hideFleetHoverCard();
       panelLayoutTimer = setTimeout(() => {
         document.body.classList.remove("three-panel-open");
+        syncAccordionLayoutMode(false);
         if (panelTelemetry) {
           panelTelemetry.classList.remove("compact-log");
         }
@@ -106,6 +108,8 @@
     sessionTime: $("#session-time"),
     roverState: $("#rover-state"),
     topoRoverLabel: $("#topo-rover .topo-node-label"),
+    leftDropdownStack: $("#left-dropdown-stack"),
+    rightDropdownStack: $("#right-dropdown-stack"),
     fleetGrid: $("#fleet-grid"),
     fleetGridSummary: $("#fleet-grid-summary"),
     fleetHoverCard: $("#fleet-hover-card"),
@@ -113,7 +117,10 @@
     fleetTotalRovers: $("#fleet-total-rovers"),
     fleetStateDistribution: $("#fleet-state-distribution"),
     fleetAvgBattery: $("#fleet-avg-battery"),
+    fleetAvgSolar: $("#fleet-avg-solar"),
+    fleetAvgRisk: $("#fleet-avg-risk"),
     fleetCommandAck: $("#fleet-command-ack"),
+    fleetMissionContext: $("#fleet-mission-context"),
     telemetryFeed: $("#telemetry-feed"),
     telemetryLastValue: $("#telemetry-last-value"),
     lunarMeta: $("#lunar-meta"),
@@ -123,9 +130,24 @@
     packetsSent: $("#packets-sent"),
     packetsReceived: $("#packets-received"),
     packetsDropped: $("#packets-dropped"),
+    missionPresetSelect: $("#mission-preset-select"),
+    missionControlsBlock: $("#mission-controls-block"),
+    missionExplanationBlock: $("#mission-explanation-block"),
+    missionBriefCode: $("#mission-brief-code"),
+    missionBriefPhase: $("#mission-brief-phase"),
+    missionBriefSummary: $("#mission-brief-summary"),
+    missionBriefTags: $("#mission-brief-tags"),
+    missionStepList: $("#mission-step-list"),
+    missionApplyBtn: $("#mission-apply-btn"),
+    missionNextStepBtn: $("#mission-next-step-btn"),
+    missionResetBtn: $("#mission-reset-btn"),
     taskIdInput: $("#task-id-input"),
+    taskIdAutoToggle: $("#task-id-auto-toggle"),
+    taskIdRegenerateBtn: $("#task-id-regenerate-btn"),
+    taskIdPreview: $("#task-id-preview"),
     taskTypeSelect: $("#task-type-select"),
     taskDifficultySelect: $("#task-difficulty-select"),
+    targetSiteInput: $("#target-site-input"),
     roverTargetSelect: $("#rover-target-select"),
     latencySlider: $("#latency-slider"),
     latencyValue: $("#latency-value"),
@@ -137,6 +159,155 @@
     faultProbValue: $("#fault-prob-value"),
     topologyVisual: $("#topology-visual"),
   };
+
+  const ACCORDION_GROUP_CONFIG = {
+    "left-orbital": { singleOpen: false, requireOneOpen: false },
+    "telemetry-orbital": { singleOpen: false, requireOneOpen: true },
+    "right-controls": { singleOpen: false, requireOneOpen: true },
+  };
+
+  function getAccordionBlocks(groupName) {
+    return Array.from(
+      document.querySelectorAll(
+        `.dropdown-block[data-accordion-group="${groupName}"]`,
+      ),
+    );
+  }
+
+  function setAccordionBlockOpen(block, open) {
+    if (!block) return;
+    const content = block.querySelector(".dropdown-content");
+    const toggle = block.querySelector(".dropdown-toggle");
+    block.classList.toggle("is-open", open);
+    if (content) content.hidden = !open;
+    if (open && content) content.scrollTop = 0;
+    if (toggle) toggle.setAttribute("aria-expanded", open ? "true" : "false");
+    if (open && block.id === "left-topology-block") {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => drawTopologyLines());
+      });
+    }
+  }
+
+  function toggleAccordionBlock(block) {
+    if (!block) return;
+    const group = String(block.dataset.accordionGroup || "");
+    const singleOpen = block.dataset.singleOpen === "true";
+    const requireOneOpen = block.dataset.requireOneOpen === "true";
+    const nextOpen = !block.classList.contains("is-open");
+
+    if (singleOpen && nextOpen && group) {
+      getAccordionBlocks(group).forEach((candidate) => {
+        if (candidate !== block) setAccordionBlockOpen(candidate, false);
+      });
+    }
+
+    if (!nextOpen && requireOneOpen && group) {
+      const openBlocks = getAccordionBlocks(group).filter((candidate) =>
+        candidate.classList.contains("is-open"),
+      );
+      if (openBlocks.length <= 1 && openBlocks[0] === block) return;
+    }
+
+    setAccordionBlockOpen(block, nextOpen);
+    if (group === "left-orbital") {
+      const topologyBlock = document.getElementById("left-topology-block");
+      if (topologyBlock?.classList.contains("is-open")) {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => drawTopologyLines());
+        });
+      }
+    }
+  }
+
+  function configureAccordionGroup(
+    groupName,
+    { singleOpen = false, requireOneOpen = false } = {},
+  ) {
+    getAccordionBlocks(groupName).forEach((block) => {
+      block.dataset.singleOpen = singleOpen ? "true" : "false";
+      block.dataset.requireOneOpen = requireOneOpen ? "true" : "false";
+    });
+  }
+
+  function ensureAccordionGroupHasOpen(groupName) {
+    const blocks = getAccordionBlocks(groupName);
+    if (blocks.length === 0) return;
+    const requireOneOpen = blocks[0].dataset.requireOneOpen === "true";
+    if (!requireOneOpen) return;
+    const openBlocks = blocks.filter((block) => block.classList.contains("is-open"));
+    if (openBlocks.length > 0) return;
+    const preferred =
+      blocks.find((block) => block.dataset.defaultOpen !== "false") || blocks[0];
+    setAccordionBlockOpen(preferred, true);
+  }
+
+  function syncAccordionLayoutMode(compact) {
+    const leftBlocks = getAccordionBlocks("left-orbital");
+    const telemetryBlocks = getAccordionBlocks("telemetry-orbital");
+
+    if (leftBlocks.length > 0) {
+      configureAccordionGroup("left-orbital", {
+        singleOpen: compact,
+        requireOneOpen: false,
+      });
+      if (compact) {
+        leftBlocks.forEach((block) => setAccordionBlockOpen(block, false));
+      } else {
+        leftBlocks.forEach((block) => {
+          const defaultOpen = block.dataset.defaultOpen !== "false";
+          setAccordionBlockOpen(block, defaultOpen);
+        });
+      }
+    }
+
+    if (telemetryBlocks.length > 0) {
+      configureAccordionGroup("telemetry-orbital", {
+        singleOpen: compact,
+        requireOneOpen: true,
+      });
+      if (compact) {
+        telemetryBlocks.forEach((block) => setAccordionBlockOpen(block, false));
+        const preferred = telemetryBlocks.find(
+          (block) => block.id === "telemetry-stream-block",
+        );
+        setAccordionBlockOpen(preferred || telemetryBlocks[0], true);
+      } else {
+        telemetryBlocks.forEach((block) => {
+          const defaultOpen = block.dataset.defaultOpen !== "false";
+          setAccordionBlockOpen(block, defaultOpen);
+        });
+        ensureAccordionGroupHasOpen("telemetry-orbital");
+      }
+    }
+  }
+
+  function initializeAccordions() {
+    const blocks = Array.from(document.querySelectorAll(".dropdown-block"));
+    blocks.forEach((block) => {
+      const toggle = block.querySelector(".dropdown-toggle");
+      if (!toggle) return;
+      toggle.addEventListener("click", () => toggleAccordionBlock(block));
+      const isOpen = block.classList.contains("is-open");
+      setAccordionBlockOpen(block, isOpen);
+    });
+    configureAccordionGroup("right-controls", {
+      singleOpen: ACCORDION_GROUP_CONFIG["right-controls"].singleOpen,
+      requireOneOpen: ACCORDION_GROUP_CONFIG["right-controls"].requireOneOpen,
+    });
+    configureAccordionGroup("telemetry-orbital", {
+      singleOpen: ACCORDION_GROUP_CONFIG["telemetry-orbital"].singleOpen,
+      requireOneOpen: ACCORDION_GROUP_CONFIG["telemetry-orbital"].requireOneOpen,
+    });
+    syncAccordionLayoutMode(document.body.classList.contains("three-panel-open"));
+    ensureAccordionGroupHasOpen("right-controls");
+    ensureAccordionGroupHasOpen("telemetry-orbital");
+  }
+
+  function openMissionControlsCard() {
+    if (!dom.missionControlsBlock) return;
+    setAccordionBlockOpen(dom.missionControlsBlock, true);
+  }
 
   function hydrateTaskSelectorsFromCatalog() {
     if (!taskCatalog || !dom.taskTypeSelect || !dom.taskDifficultySelect) return;
@@ -166,6 +337,477 @@
     }
   }
   hydrateTaskSelectorsFromCatalog();
+
+  const TASK_TYPE_CODES = {
+    movement: "MOV",
+    science: "SCI",
+    digging: "DIG",
+    pushing: "PSH",
+    photo: "IMG",
+    "sample-handling": "SMP",
+  };
+
+  const MISSION_PRESETS = {
+    "cy3-pragyan": {
+      id_code: "CY3",
+      mission_phase: "CY3-ops",
+      title: "Chandrayaan-3 Pragyan Surface Ops",
+      summary:
+        "Traverse, image, and run in-situ surface science analogs around a Pragyan-style landing zone.",
+      payload_tags: ["Pragyan", "LIBS", "APXS", "NavCam"],
+      default_target_site: "Shiv Shakti Point Sector-A",
+      steps: [
+        {
+          title: "Traverse to scan waypoint",
+          task_type: "movement",
+          difficulty_level: "L2",
+          mission_phase: "CY3-ops",
+          target_site: "Traverse Corridor-1",
+          note: "Position rover safely before instrument operations.",
+        },
+        {
+          title: "Panoramic imaging sweep",
+          task_type: "photo",
+          difficulty_level: "L1",
+          mission_phase: "CY3-ops",
+          target_site: "Panorama Ridge",
+          note: "Capture terrain mosaic for route and science planning.",
+        },
+        {
+          title: "In-situ elemental science pass",
+          task_type: "science",
+          difficulty_level: "L3",
+          mission_phase: "CY3-ops",
+          target_site: "Surface Patch LIBS-02",
+          note: "Teach payload-style analysis sequencing.",
+        },
+      ],
+    },
+    "cy4-sample-return": {
+      id_code: "CY4",
+      mission_phase: "CY4-sample-chain",
+      title: "Chandrayaan-4 Sample Return Chain",
+      summary:
+        "A teaching sequence for prospecting, extraction, sample custody, and transfer preparation.",
+      payload_tags: ["Sampling Drill", "Transfer Canister", "Surface Relay"],
+      default_target_site: "Sample Depot Alpha",
+      steps: [
+        {
+          title: "Prospecting traverse to candidate site",
+          task_type: "movement",
+          difficulty_level: "L3",
+          mission_phase: "CY4-sample-chain",
+          target_site: "Candidate Site CY4-7",
+          note: "Reach site with enough battery and comm margin.",
+        },
+        {
+          title: "Volatile prospecting scan",
+          task_type: "science",
+          difficulty_level: "L3",
+          mission_phase: "CY4-sample-chain",
+          target_site: "Candidate Site CY4-7",
+          note: "Run spectroscopy-like measurement cycle.",
+        },
+        {
+          title: "Core extraction",
+          task_type: "digging",
+          difficulty_level: "L4",
+          mission_phase: "CY4-sample-chain",
+          target_site: "Drill Spot CY4-7B",
+          note: "Higher thermal and terrain stress during drilling.",
+        },
+        {
+          title: "Sample transfer and custody check",
+          task_type: "sample-handling",
+          difficulty_level: "L4",
+          mission_phase: "CY4-sample-chain",
+          target_site: "Sample Depot Alpha",
+          note: "Validate chain-of-custody workflow for return prep.",
+        },
+      ],
+    },
+    "lupex-polar-ice": {
+      id_code: "LXP",
+      mission_phase: "LUPEX-prospecting",
+      title: "LUPEX Polar Ice Prospecting",
+      summary:
+        "Polar traverse and subsurface investigation sequence focused on volatile resource mapping.",
+      payload_tags: ["Polar Traverse", "Volatile Mapping", "Drill Ops"],
+      default_target_site: "Polar Shadow Boundary",
+      steps: [
+        {
+          title: "Low-light approach traverse",
+          task_type: "movement",
+          difficulty_level: "L4",
+          mission_phase: "LUPEX-prospecting",
+          target_site: "Shadow Boundary Route-3",
+          note: "Night/terminator margins strongly influence risk.",
+        },
+        {
+          title: "High-fidelity imaging survey",
+          task_type: "photo",
+          difficulty_level: "L2",
+          mission_phase: "LUPEX-prospecting",
+          target_site: "Polar Survey Grid",
+          note: "Map hazard zones before drilling.",
+        },
+        {
+          title: "Subsurface excavation run",
+          task_type: "digging",
+          difficulty_level: "L5",
+          mission_phase: "LUPEX-prospecting",
+          target_site: "Ice Prospect Borehole",
+          note: "Max difficulty case for environment-aware planning.",
+        },
+      ],
+    },
+    "cy-future-base": {
+      id_code: "CYB",
+      mission_phase: "base-build",
+      title: "Future Chandrayaan Base Build",
+      summary:
+        "Multipurpose swarm scenario for regolith logistics, infrastructure staging, and base readiness.",
+      payload_tags: ["Swarm Ops", "Regolith Handling", "Infrastructure Build"],
+      default_target_site: "Bharati Base Site-01",
+      steps: [
+        {
+          title: "Route clearance traverse",
+          task_type: "movement",
+          difficulty_level: "L2",
+          mission_phase: "base-build",
+          target_site: "Access Corridor-B",
+          note: "Prepare route before heavy logistics tasks.",
+        },
+        {
+          title: "Regolith push and berm shaping",
+          task_type: "pushing",
+          difficulty_level: "L4",
+          mission_phase: "base-build",
+          target_site: "Shield Berm Segment-2",
+          note: "Material handling under traction limits.",
+        },
+        {
+          title: "Excavation for foundation trench",
+          task_type: "digging",
+          difficulty_level: "L4",
+          mission_phase: "base-build",
+          target_site: "Foundation Trench-A",
+          note: "Excavation workload for habitat anchoring.",
+        },
+        {
+          title: "Sample transfer to processing bay",
+          task_type: "sample-handling",
+          difficulty_level: "L3",
+          mission_phase: "base-build",
+          target_site: "ISRU Processing Bay",
+          note: "Logistics hand-off between rover roles.",
+        },
+        {
+          title: "Post-build imaging verification",
+          task_type: "photo",
+          difficulty_level: "L2",
+          mission_phase: "base-build",
+          target_site: "Base Site Panorama Mast",
+          note: "Visual QA pass for teaching mission closure.",
+        },
+      ],
+    },
+  };
+
+  const DEFAULT_MISSION_PRESET = "cy3-pragyan";
+  const missionPresetKeys = Object.keys(MISSION_PRESETS);
+  const taskIdCounters = {};
+  const missionGuideState = {
+    presetKey: DEFAULT_MISSION_PRESET,
+    completedCount: 0,
+    activeStepIndex: 0,
+    currentMissionPhase: MISSION_PRESETS[DEFAULT_MISSION_PRESET].mission_phase,
+  };
+  let taskIdDirty = false;
+  let suppressTaskIdInputTracking = false;
+
+  function safeMissionPresetKey(rawKey) {
+    const key = String(rawKey || "").trim();
+    return missionPresetKeys.includes(key) ? key : DEFAULT_MISSION_PRESET;
+  }
+
+  function getActiveMissionPreset() {
+    return MISSION_PRESETS[safeMissionPresetKey(missionGuideState.presetKey)];
+  }
+
+  function getTaskTypeConfig(taskType) {
+    return taskCatalog?.task_types?.[taskType] || null;
+  }
+
+  function sanitizeTaskToken(value, fallback = "TASK") {
+    const token = String(value || "")
+      .trim()
+      .toUpperCase()
+      .replace(/[^A-Z0-9]+/g, "-")
+      .replace(/(^-+|-+$)/g, "");
+    return token || fallback;
+  }
+
+  function getTaskIdContext() {
+    const preset = getActiveMissionPreset();
+    const taskType = String(dom.taskTypeSelect?.value || "movement")
+      .trim()
+      .toLowerCase();
+    const difficulty = String(dom.taskDifficultySelect?.value || "L2")
+      .trim()
+      .toUpperCase();
+    const missionCode = sanitizeTaskToken(preset.id_code || "CYX", "CYX");
+    const taskCode = TASK_TYPE_CODES[taskType] || sanitizeTaskToken(taskType, "TASK").slice(0, 4);
+    const difficultyCode = /^L[1-5]$/.test(difficulty) ? difficulty : "L2";
+
+    return {
+      missionCode,
+      taskCode,
+      difficultyCode,
+    };
+  }
+
+  function formatTaskId(context, sequence) {
+    return `${context.missionCode}-${context.taskCode}-${context.difficultyCode}-${String(sequence).padStart(3, "0")}`;
+  }
+
+  function peekGeneratedTaskId() {
+    const context = getTaskIdContext();
+    const counterKey = `${context.missionCode}:${context.taskCode}:${context.difficultyCode}`;
+    const sequence = taskIdCounters[counterKey] || 1;
+    return formatTaskId(context, sequence);
+  }
+
+  function reserveGeneratedTaskId() {
+    const context = getTaskIdContext();
+    const counterKey = `${context.missionCode}:${context.taskCode}:${context.difficultyCode}`;
+    const sequence = taskIdCounters[counterKey] || 1;
+    taskIdCounters[counterKey] = sequence + 1;
+    return formatTaskId(context, sequence);
+  }
+
+  function updateTaskIdPreview() {
+    if (!dom.taskIdPreview) return;
+    const suggested = peekGeneratedTaskId();
+    if (!dom.taskIdAutoToggle?.checked) {
+      dom.taskIdPreview.textContent = `Manual mode · Suggested ${suggested}`;
+      return;
+    }
+    dom.taskIdPreview.textContent = taskIdDirty
+      ? `Manual override · Suggested ${suggested}`
+      : `Next ${suggested}`;
+  }
+
+  function syncTaskIdInput({ force = false } = {}) {
+    if (!dom.taskIdInput) return null;
+    const generated = peekGeneratedTaskId();
+    const current = String(dom.taskIdInput.value || "").trim();
+    const canApplyAuto = dom.taskIdAutoToggle?.checked && !taskIdDirty;
+    if (force || !current || canApplyAuto) {
+      suppressTaskIdInputTracking = true;
+      dom.taskIdInput.value = generated;
+      suppressTaskIdInputTracking = false;
+      taskIdDirty = false;
+    }
+    updateTaskIdPreview();
+    return generated;
+  }
+
+  function markTaskIdAsDispatched() {
+    reserveGeneratedTaskId();
+    if (dom.taskIdAutoToggle?.checked) {
+      taskIdDirty = false;
+      syncTaskIdInput({ force: true });
+    } else {
+      updateTaskIdPreview();
+    }
+  }
+
+  function getMissionStepList() {
+    return getActiveMissionPreset().steps || [];
+  }
+
+  function getActiveMissionStep() {
+    const steps = getMissionStepList();
+    if (steps.length === 0) return null;
+    const clampedIndex = Math.max(0, Math.min(missionGuideState.activeStepIndex, steps.length - 1));
+    return steps[clampedIndex];
+  }
+
+  function setMissionGuidePhase(nextPhase) {
+    missionGuideState.currentMissionPhase = String(nextPhase || "").trim() || getActiveMissionPreset().mission_phase;
+    if (dom.missionBriefPhase) {
+      dom.missionBriefPhase.textContent = missionGuideState.currentMissionPhase;
+    }
+  }
+
+  function renderMissionBrief() {
+    const preset = getActiveMissionPreset();
+    if (dom.missionPresetSelect) {
+      dom.missionPresetSelect.value = safeMissionPresetKey(preset && missionGuideState.presetKey);
+    }
+    if (dom.missionBriefCode) dom.missionBriefCode.textContent = preset.id_code;
+    if (dom.missionBriefSummary) dom.missionBriefSummary.textContent = preset.summary;
+    setMissionGuidePhase(missionGuideState.currentMissionPhase || preset.mission_phase);
+    if (dom.missionBriefTags) {
+      dom.missionBriefTags.innerHTML = (preset.payload_tags || [])
+        .map((tag) => `<span class="mission-brief-tag">${escapeHtml(tag)}</span>`)
+        .join("");
+    }
+  }
+
+  function renderMissionStepList() {
+    if (!dom.missionStepList) return;
+    const steps = getMissionStepList();
+    if (steps.length === 0) {
+      dom.missionStepList.innerHTML = "";
+      return;
+    }
+
+    const nextIndex = Math.min(missionGuideState.completedCount, steps.length - 1);
+    dom.missionStepList.innerHTML = steps
+      .map((step, index) => {
+        const isComplete = index < missionGuideState.completedCount;
+        const isNext = missionGuideState.completedCount < steps.length && index === nextIndex;
+        const isApplied = index === missionGuideState.activeStepIndex;
+        const classes = [
+          "mission-step-item",
+          isComplete ? "is-complete" : "",
+          isNext ? "is-next" : "",
+          isApplied ? "is-applied" : "",
+        ]
+          .filter(Boolean)
+          .join(" ");
+
+        return `
+          <li class="${classes}" data-step-index="${index}">
+            <div class="mission-step-title">
+              <span>${index + 1}. ${escapeHtml(step.title || "Step")}</span>
+              <span class="mission-step-badge">${isComplete ? "DONE" : isNext ? "NEXT" : "PLAN"}</span>
+            </div>
+            <div class="mission-step-meta">
+              <span class="mission-step-chip">${escapeHtml(step.task_type || "movement")}</span>
+              <span class="mission-step-chip">${escapeHtml(step.difficulty_level || "L2")}</span>
+            </div>
+            <div class="mission-step-note">${escapeHtml(step.note || "")}</div>
+          </li>
+        `;
+      })
+      .join("");
+  }
+
+  function applyMissionStepToControls(
+    step,
+    { announce = false, forceTaskId = false } = {},
+  ) {
+    if (!step) return;
+
+    if (dom.taskTypeSelect && step.task_type && dom.taskTypeSelect.querySelector(`option[value="${step.task_type}"]`)) {
+      dom.taskTypeSelect.value = step.task_type;
+    }
+    if (
+      dom.taskDifficultySelect &&
+      step.difficulty_level &&
+      dom.taskDifficultySelect.querySelector(`option[value="${step.difficulty_level}"]`)
+    ) {
+      dom.taskDifficultySelect.value = step.difficulty_level;
+    }
+    if (dom.targetSiteInput) {
+      dom.targetSiteInput.value = step.target_site || getActiveMissionPreset().default_target_site || "";
+    }
+    setMissionGuidePhase(step.mission_phase || getActiveMissionPreset().mission_phase);
+    if (forceTaskId) {
+      taskIdDirty = false;
+      syncTaskIdInput({ force: true });
+    } else {
+      syncTaskIdInput();
+    }
+    renderMissionStepList();
+
+    if (announce) {
+      addFeedLine(
+        "system",
+        `📘 Mission step ready: ${step.title} (${step.task_type}/${step.difficulty_level})`,
+      );
+    }
+  }
+
+  function setMissionPreset(presetKey, { announce = false, resetProgress = true } = {}) {
+    missionGuideState.presetKey = safeMissionPresetKey(presetKey);
+    const preset = getActiveMissionPreset();
+    if (resetProgress) {
+      missionGuideState.completedCount = 0;
+      missionGuideState.activeStepIndex = 0;
+    } else {
+      missionGuideState.activeStepIndex = Math.max(
+        0,
+        Math.min(
+          missionGuideState.activeStepIndex,
+          Math.max(0, (preset.steps || []).length - 1),
+        ),
+      );
+    }
+    setMissionGuidePhase(preset.mission_phase);
+    renderMissionBrief();
+    renderMissionStepList();
+    applyMissionStepToControls(getActiveMissionStep(), {
+      announce: false,
+      forceTaskId: true,
+    });
+
+    if (announce) {
+      addFeedLine("system", `🛰️ Mission preset loaded: ${preset.title}`);
+    }
+  }
+
+  function setMissionActiveStep(index, { announce = false } = {}) {
+    const steps = getMissionStepList();
+    if (steps.length === 0) return;
+    missionGuideState.activeStepIndex = Math.max(0, Math.min(index, steps.length - 1));
+    applyMissionStepToControls(getActiveMissionStep(), {
+      announce,
+      forceTaskId: true,
+    });
+  }
+
+  function moveMissionActiveStep(delta) {
+    const steps = getMissionStepList();
+    if (steps.length === 0) return;
+    setMissionActiveStep(missionGuideState.activeStepIndex + delta, { announce: true });
+  }
+
+  function advanceMissionGuideAfterDispatch() {
+    const steps = getMissionStepList();
+    if (steps.length === 0) return;
+
+    if (missionGuideState.activeStepIndex >= missionGuideState.completedCount) {
+      missionGuideState.completedCount = Math.min(
+        steps.length,
+        missionGuideState.activeStepIndex + 1,
+      );
+    }
+
+    if (missionGuideState.completedCount >= steps.length) {
+      missionGuideState.activeStepIndex = steps.length - 1;
+      renderMissionStepList();
+      addFeedLine("system", "✅ Mission guide sequence complete. Use Reset Guide to run again.");
+      return;
+    }
+
+    missionGuideState.activeStepIndex = missionGuideState.completedCount;
+    applyMissionStepToControls(getActiveMissionStep(), {
+      announce: false,
+      forceTaskId: true,
+    });
+  }
+
+  function ensureDispatchTaskId() {
+    const existing = String(dom.taskIdInput?.value || "").trim();
+    if (existing) return existing;
+    taskIdDirty = false;
+    syncTaskIdInput({ force: true });
+    return String(dom.taskIdInput?.value || "").trim() || peekGeneratedTaskId();
+  }
 
   const AUTO_ROVER_MODE = "auto";
   const roverIdCollator = new Intl.Collator(undefined, {
@@ -211,10 +853,22 @@
     const difficultyLevel = String(dom.taskDifficultySelect?.value || "L2")
       .trim()
       .toUpperCase();
+    const taskTypeCfg = getTaskTypeConfig(taskType);
+    const requiredCapabilities = Array.isArray(taskTypeCfg?.required_capabilities)
+      ? [...taskTypeCfg.required_capabilities]
+      : [];
+    const targetSiteRaw = String(dom.targetSiteInput?.value || "").trim();
+
     return {
       task_id: taskIdRaw.trim() || "TASK-001",
       task_type: taskType || "movement",
       difficulty_level: difficultyLevel || "L2",
+      required_capabilities: requiredCapabilities,
+      mission_phase:
+        missionGuideState.currentMissionPhase ||
+        taskTypeCfg?.mission_phase ||
+        getActiveMissionPreset().mission_phase,
+      target_site: targetSiteRaw || null,
     };
   }
 
@@ -445,13 +1099,19 @@
     };
 
     let batterySum = 0;
+    let solarSum = 0;
+    let riskSum = 0;
     entries.forEach((snapshot) => {
       const state = normalizeState(snapshot.state);
       counts[state] = (counts[state] || 0) + 1;
       batterySum += snapshot.battery || 0;
+      solarSum += snapshot.solar_exposure || 0;
+      riskSum += Number(snapshot.predicted_fault_probability || 0);
     });
 
     const avgBattery = total === 0 ? 0 : Math.round((batterySum / total) * 100);
+    const avgSolar = total === 0 ? 0 : Math.round((solarSum / total) * 100);
+    const avgRisk = total === 0 ? 0 : (riskSum / total) * 100;
 
     if (dom.fleetTotalRovers) dom.fleetTotalRovers.textContent = String(total);
     if (dom.fleetStateDistribution) {
@@ -459,9 +1119,20 @@
         `${counts.IDLE || 0} IDLE · ${counts.EXECUTING || 0} EXECUTING · ${counts.SAFE_MODE || 0} SAFE_MODE`;
     }
     if (dom.fleetAvgBattery) dom.fleetAvgBattery.textContent = `${avgBattery}%`;
+    if (dom.fleetAvgSolar) dom.fleetAvgSolar.textContent = `${avgSolar}%`;
+    if (dom.fleetAvgRisk) dom.fleetAvgRisk.textContent = `${avgRisk.toFixed(1)}%`;
     if (dom.fleetCommandAck) {
       dom.fleetCommandAck.textContent =
         `${trafficCounters.commandsSent} / ${trafficCounters.acksReceived}`;
+    }
+    if (dom.fleetMissionContext) {
+      const steps = getMissionStepList();
+      const stepTotal = steps.length;
+      const stepCurrent = stepTotal > 0
+        ? Math.min(missionGuideState.activeStepIndex + 1, stepTotal)
+        : 0;
+      dom.fleetMissionContext.textContent =
+        `${missionGuideState.currentMissionPhase || "mission"} · Step ${stepCurrent}/${stepTotal || 0}`;
     }
   }
 
@@ -628,11 +1299,16 @@
   function dispatchCommand(commandType, taskId = null) {
     let roverId = resolveTargetRover(commandType);
     let taskOptions = null;
+    let resolvedTaskId = taskId;
 
     if (commandType === "START_TASK") {
-      const selectedTask = getSelectedTaskConfig(taskId);
+      resolvedTaskId = taskId || ensureDispatchTaskId();
+      const selectedTask = getSelectedTaskConfig(resolvedTaskId);
       if (roverTargetMode === AUTO_ROVER_MODE) {
-        const assignment = sim.selectBestRoverForTask(selectedTask.task_id, selectedTask);
+        const assignment = sim.selectBestRoverForTask(
+          selectedTask.task_id,
+          selectedTask,
+        );
         roverId = assignment?.selected_rover || null;
         if (!roverId) {
           addFeedLine(
@@ -652,8 +1328,6 @@
       } else {
         taskOptions = {
           ...selectedTask,
-          mission_phase: "CY3-ops",
-          target_site: null,
           selected_rover: roverId,
         };
       }
@@ -665,13 +1339,17 @@
     }
 
     setSelectedRover(roverId);
-    const cmdId = sim.sendCommand(commandType, taskId, roverId, taskOptions);
+    const cmdId = sim.sendCommand(commandType, resolvedTaskId, roverId, taskOptions);
     if (roverTargetMode === AUTO_ROVER_MODE && cmdId) {
       const taskSuffix =
         commandType === "START_TASK" && taskOptions
           ? ` (${taskOptions.task_type}/${taskOptions.difficulty_level})`
           : "";
       addFeedLine("system", `🎯 Auto-selected ${formatRoverLabel(roverId)} for ${commandType}${taskSuffix}`);
+    }
+    if (commandType === "START_TASK" && cmdId) {
+      advanceMissionGuideAfterDispatch();
+      markTaskIdAsDispatched();
     }
     return cmdId;
   }
@@ -697,7 +1375,12 @@
   function applyScenarioFromUrl() {
     const params = new URLSearchParams(window.location.search || "");
     const scenario = String(params.get("scenario") || "").toLowerCase();
-    const taskId = (params.get("task") || dom.taskIdInput?.value || "TASK-001").trim();
+    const missionPreset = safeMissionPresetKey(
+      params.get("mission") || missionGuideState.presetKey,
+    );
+    setMissionPreset(missionPreset, { announce: false, resetProgress: true });
+
+    const taskId = String(params.get("task") || dom.taskIdInput?.value || "").trim();
     const taskType = String(params.get("task_type") || dom.taskTypeSelect?.value || "movement")
       .trim()
       .toLowerCase();
@@ -706,6 +1389,7 @@
     )
       .trim()
       .toUpperCase();
+    const targetSite = String(params.get("target_site") || "").trim();
     const requestedView = String(params.get("view") || "").toLowerCase();
     const open3d = String(params.get("open3d") || "").toLowerCase();
     const delayMs = Math.max(
@@ -713,10 +1397,22 @@
       Math.round(Number(params.get("delay_ms")) || 1800),
     );
 
-    if (dom.taskIdInput && taskId) dom.taskIdInput.value = taskId;
+    if (dom.taskIdInput && taskId) {
+      dom.taskIdInput.value = taskId;
+      taskIdDirty = true;
+    }
     if (dom.taskTypeSelect && taskType) dom.taskTypeSelect.value = taskType;
     if (dom.taskDifficultySelect && difficultyLevel) {
       dom.taskDifficultySelect.value = difficultyLevel;
+    }
+    if (dom.targetSiteInput && targetSite) {
+      dom.targetSiteInput.value = targetSite;
+    }
+    if (!taskId) {
+      taskIdDirty = false;
+      syncTaskIdInput();
+    } else {
+      updateTaskIdPreview();
     }
 
     if (open3d === "1" || open3d === "true" || open3d === "yes") {
@@ -761,22 +1457,22 @@
     switch (scenario) {
       case "basic-auto":
         setRoverTargetMode(AUTO_ROVER_MODE);
-        setTimeout(() => dispatchCommand("START_TASK", taskId || "AUTO-001"), delayMs);
+        setTimeout(() => dispatchCommand("START_TASK", taskId || ensureDispatchTaskId()), delayMs);
         break;
       case "manual-select": {
         const manualRover = params.get("manual_rover") || "rover-2";
         setRoverTargetMode(manualRover);
-        setTimeout(() => dispatchCommand("START_TASK", taskId || "MANUAL-001"), delayMs);
+        setTimeout(() => dispatchCommand("START_TASK", taskId || ensureDispatchTaskId()), delayMs);
         break;
       }
       case "safe-mode":
         setRoverTargetMode(AUTO_ROVER_MODE);
-        setTimeout(() => dispatchCommand("START_TASK", taskId || "SAFE-001"), delayMs);
+        setTimeout(() => dispatchCommand("START_TASK", taskId || ensureDispatchTaskId()), delayMs);
         setTimeout(() => dispatchCommand("GO_SAFE"), delayMs + 3000);
         break;
       case "battery-select":
         setRoverTargetMode(AUTO_ROVER_MODE);
-        setTimeout(() => dispatchCommand("START_TASK", taskId || "BATT-001"), delayMs);
+        setTimeout(() => dispatchCommand("START_TASK", taskId || ensureDispatchTaskId()), delayMs);
         break;
       default:
         break;
@@ -792,6 +1488,7 @@
   }
 
   // Initialize fleet cache from simulation startup state
+  initializeAccordions();
   loadPinnedRovers();
   attachFleetInteractions();
 
@@ -1065,7 +1762,9 @@
   // ─── Topology Lines ───
   function drawTopologyLines() {
     const svg = document.getElementById("topology-lines");
+    if (!svg || !dom.topologyVisual) return;
     const containerRect = dom.topologyVisual.getBoundingClientRect();
+    if (containerRect.width <= 0 || containerRect.height <= 0) return;
 
     const nodes = [
       "topo-earth",
@@ -1077,12 +1776,17 @@
 
     nodes.forEach((id) => {
       const el = document.getElementById(id);
+      if (!el) return;
       const rect = el.getBoundingClientRect();
       positions[id] = {
         x: rect.left + rect.width / 2 - containerRect.left,
         y: rect.top + rect.height / 2 - containerRect.top,
       };
     });
+
+    if (!positions["topo-earth"] || !positions["topo-spacelink"] || !positions["topo-rover"] || !positions["topo-telemetry"]) {
+      return;
+    }
 
     svg.innerHTML = "";
     svg.setAttribute(
@@ -1133,8 +1837,103 @@
     });
   }
 
+  if (dom.missionPresetSelect) {
+    dom.missionPresetSelect.addEventListener("change", (event) => {
+      setMissionPreset(event.target.value, { announce: true, resetProgress: true });
+      openMissionControlsCard();
+    });
+  }
+
+  if (dom.missionApplyBtn) {
+    dom.missionApplyBtn.addEventListener("click", () => {
+      applyMissionStepToControls(getActiveMissionStep(), {
+        announce: true,
+        forceTaskId: true,
+      });
+      openMissionControlsCard();
+      pulseButton(dom.missionApplyBtn);
+    });
+  }
+
+  if (dom.missionNextStepBtn) {
+    dom.missionNextStepBtn.addEventListener("click", () => {
+      moveMissionActiveStep(1);
+      openMissionControlsCard();
+      pulseButton(dom.missionNextStepBtn);
+    });
+  }
+
+  if (dom.missionResetBtn) {
+    dom.missionResetBtn.addEventListener("click", () => {
+      missionGuideState.completedCount = 0;
+      missionGuideState.activeStepIndex = 0;
+      setMissionGuidePhase(getActiveMissionPreset().mission_phase);
+      applyMissionStepToControls(getActiveMissionStep(), {
+        announce: true,
+        forceTaskId: true,
+      });
+      openMissionControlsCard();
+      pulseButton(dom.missionResetBtn);
+    });
+  }
+
+  if (dom.missionStepList) {
+    dom.missionStepList.addEventListener("click", (event) => {
+      const item = event.target.closest(".mission-step-item");
+      if (!item) return;
+      const stepIndex = Number(item.dataset.stepIndex);
+      if (!Number.isFinite(stepIndex)) return;
+      setMissionActiveStep(stepIndex, { announce: true });
+      openMissionControlsCard();
+    });
+  }
+
+  if (dom.taskIdInput) {
+    dom.taskIdInput.addEventListener("input", () => {
+      if (suppressTaskIdInputTracking) return;
+      taskIdDirty = true;
+      updateTaskIdPreview();
+    });
+  }
+
+  if (dom.taskIdAutoToggle) {
+    dom.taskIdAutoToggle.addEventListener("change", () => {
+      if (dom.taskIdAutoToggle.checked) {
+        taskIdDirty = false;
+        syncTaskIdInput({ force: true });
+        addFeedLine("system", "🧾 Auto task ID generation enabled");
+      } else {
+        updateTaskIdPreview();
+        addFeedLine("system", "🧾 Manual task ID mode enabled");
+      }
+    });
+  }
+
+  if (dom.taskIdRegenerateBtn) {
+    dom.taskIdRegenerateBtn.addEventListener("click", () => {
+      taskIdDirty = false;
+      syncTaskIdInput({ force: true });
+      addFeedLine("system", `🧾 Task ID regenerated: ${dom.taskIdInput.value}`);
+      pulseButton(dom.taskIdRegenerateBtn);
+    });
+  }
+
+  if (dom.taskTypeSelect) {
+    dom.taskTypeSelect.addEventListener("change", () => {
+      syncTaskIdInput();
+      updateTaskIdPreview();
+    });
+  }
+
+  if (dom.taskDifficultySelect) {
+    dom.taskDifficultySelect.addEventListener("change", () => {
+      syncTaskIdInput();
+      updateTaskIdPreview();
+    });
+  }
+
   $("#cmd-start-task").addEventListener("click", () => {
-    const taskId = dom.taskIdInput.value.trim() || "TASK-001";
+    const taskId = ensureDispatchTaskId();
     dispatchCommand("START_TASK", taskId);
     pulseButton($("#cmd-start-task"));
   });
@@ -1257,7 +2056,7 @@
           dispatchCommand("GO_SAFE");
           pulseButton($("#cmd-go-safe"));
         } else {
-          const taskId = dom.taskIdInput.value.trim() || "TASK-001";
+          const taskId = ensureDispatchTaskId();
           dispatchCommand("START_TASK", taskId);
           pulseButton($("#cmd-start-task"));
         }

--- a/web-sim/index.css
+++ b/web-sim/index.css
@@ -298,7 +298,7 @@ h4 {
   margin: var(--panel-gap) var(--panel-gap) 0;
   padding: var(--sp-sm) var(--sp-lg);
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: var(--sp-md);
   background: var(--bg-panel);
   backdrop-filter: saturate(180%) blur(20px);
@@ -435,9 +435,158 @@ body.three-panel-open #main-grid {
    TOPOLOGY PANEL (LEFT)
    ═══════════════════════════════════════════════════════ */
 .panel-topology {
-  overflow: visible;
+  overflow-y: auto;
   grid-column: 1;
   transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.dropdown-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-sm);
+  min-height: 0;
+}
+
+.left-dropdown-stack {
+  padding: 0 var(--sp-md) var(--sp-md);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.right-dropdown-stack {
+  padding: 0 var(--sp-lg) var(--sp-lg);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.right-dropdown-stack > .dropdown-block {
+  flex: 0 0 auto;
+  min-height: fit-content;
+}
+
+.right-dropdown-stack > .dropdown-block > .dropdown-content {
+  overflow: visible;
+  max-height: none;
+}
+
+.dropdown-block {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.dropdown-toggle {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  padding: var(--sp-sm) var(--sp-md);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-sm);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition-fast);
+}
+
+.dropdown-toggle:hover {
+  background: var(--bg-hover);
+}
+
+.dropdown-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dropdown-meta {
+  max-width: 44%;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dropdown-toggle .pending-count {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.dropdown-chevron {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-right: 1.5px solid var(--text-tertiary);
+  border-bottom: 1.5px solid var(--text-tertiary);
+  transform: rotate(45deg);
+  margin-right: 2px;
+  transition: transform var(--transition-fast);
+}
+
+.dropdown-block.is-open .dropdown-chevron {
+  transform: rotate(-135deg);
+  margin-top: 4px;
+}
+
+.dropdown-content {
+  padding: 0 var(--sp-sm) var(--sp-sm);
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.left-dropdown-stack .dropdown-block.is-open,
+.telemetry-dropdown-stack .dropdown-block.is-open {
+  flex: 1;
+}
+
+.left-dropdown-stack .dropdown-content,
+.telemetry-dropdown-stack .dropdown-content {
+  max-height: none;
+  flex: 1;
+}
+
+#left-command-log-block .dropdown-content:not([hidden]) {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+#left-pending-ack-block .dropdown-content:not([hidden]) {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+#telemetry-stream-block .dropdown-content:not([hidden]) {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+#telemetry-stream-block .telemetry-feed {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.dropdown-content[hidden] {
+  display: none;
 }
 
 .topology-visual {
@@ -516,6 +665,32 @@ body.three-panel-open #main-grid {
   transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+.telemetry-dropdown-stack {
+  padding: 0 var(--sp-lg) var(--sp-lg);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.telemetry-dropdown-stack .fleet-grid-panel,
+.telemetry-dropdown-stack .telemetry-feed {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.telemetry-dropdown-stack .fleet-grid-panel {
+  margin-bottom: 0;
+}
+
+.telemetry-dropdown-stack .telemetry-feed {
+  max-height: none;
+  margin-bottom: 0;
+}
+
+.telemetry-dropdown-stack .telemetry-last-line {
+  margin: var(--sp-sm) 0 0;
+}
+
 body.three-panel-open .panel-telemetry.compact-log {
   transform: none;
   grid-column: 1;
@@ -524,21 +699,42 @@ body.three-panel-open .panel-telemetry.compact-log {
   min-height: 0;
 }
 
+body.three-panel-open .telemetry-dropdown-stack {
+  gap: 6px;
+  padding: 0 var(--sp-sm) var(--sp-sm);
+  height: 100%;
+}
+
+body.three-panel-open .telemetry-dropdown-stack .dropdown-toggle {
+  padding: 7px 8px;
+}
+
+body.three-panel-open .telemetry-dropdown-stack .dropdown-title {
+  font-size: 10px;
+}
+
+body.three-panel-open .telemetry-dropdown-stack .dropdown-meta {
+  font-size: 9px;
+}
+
+body.three-panel-open .telemetry-dropdown-stack .dropdown-content {
+  max-height: none;
+  padding: 0 6px 6px;
+}
+
+body.three-panel-open #telemetry-stream-block .dropdown-content:not([hidden]) {
+  overflow: hidden;
+}
+
+body.three-panel-open #telemetry-stream-block .telemetry-feed {
+  min-height: 0;
+  overflow-y: auto;
+}
+
 body.three-panel-open .panel-topology {
   grid-column: 1;
   grid-row: 1;
   align-self: start;
-}
-
-body.three-panel-open .panel-topology .topology-visual,
-body.three-panel-open .panel-topology .signal-legend {
-  opacity: 0;
-  max-height: 0;
-  overflow: hidden;
-  pointer-events: none;
-  padding-top: 0;
-  padding-bottom: 0;
-  margin: 0;
 }
 
 .panel-topology .topology-visual {
@@ -558,7 +754,75 @@ body.three-panel-open .panel-topology .signal-legend {
 }
 
 body.three-panel-open .panel-topology .panel-header {
-  padding-bottom: var(--sp-lg);
+  padding-bottom: var(--sp-sm);
+}
+
+body.three-panel-open #left-dropdown-stack {
+  gap: 6px;
+  padding: 0 var(--sp-sm) var(--sp-sm);
+}
+
+body.three-panel-open #left-dropdown-stack .dropdown-toggle {
+  padding: 7px 8px;
+}
+
+body.three-panel-open #left-dropdown-stack .dropdown-title {
+  font-size: 10px;
+}
+
+body.three-panel-open #left-dropdown-stack .dropdown-meta {
+  font-size: 9px;
+}
+
+body.three-panel-open #left-dropdown-stack .dropdown-content {
+  padding: 0 6px 6px;
+}
+
+body.three-panel-open #left-dropdown-stack .topology-visual {
+  padding: 6px;
+  gap: 6px;
+  max-height: none;
+  min-height: 176px;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  align-content: space-evenly;
+}
+
+body.three-panel-open #left-dropdown-stack .signal-legend {
+  display: none;
+}
+
+body.three-panel-open #left-topology-block .topo-node {
+  width: calc(50% - 6px);
+  gap: 4px;
+}
+
+body.three-panel-open #left-topology-block .topo-node-ring {
+  width: 40px;
+  height: 40px;
+}
+
+body.three-panel-open #left-topology-block .topo-node-icon {
+  font-size: 16px;
+}
+
+body.three-panel-open #left-topology-block .topo-node-label {
+  font-size: 9px;
+}
+
+body.three-panel-open #left-topology-block .topo-node-state {
+  font-size: 8px;
+  padding: 1px 6px;
+}
+
+body.three-panel-open #left-dropdown-stack .command-log-left {
+  max-height: 96px;
+}
+
+body.three-panel-open #left-dropdown-stack .pending-acks-left {
+  max-height: 80px;
+  overflow-y: auto;
 }
 
 body.three-panel-open #floating-panel {
@@ -1287,6 +1551,24 @@ body.three-panel-open .panel-telemetry.compact-log .telemetry-last-line {
   padding: 0 var(--sp-lg) var(--sp-lg);
 }
 
+.command-section.command-section-inner {
+  padding: var(--sp-sm) 2px 2px;
+}
+
+.nested-dropdown-block {
+  margin-top: var(--sp-sm);
+  border-color: var(--border-medium);
+}
+
+.nested-dropdown-block .dropdown-toggle {
+  padding-inline: var(--sp-sm);
+}
+
+.nested-dropdown-block .dropdown-content {
+  max-height: 220px;
+  padding-inline: var(--sp-xs);
+}
+
 .command-section h3 {
   font-size: 11px;
   font-weight: 600;
@@ -1296,11 +1578,171 @@ body.three-panel-open .panel-telemetry.compact-log .telemetry-last-line {
   margin-bottom: var(--sp-sm);
 }
 
+.control-subheading {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  margin: var(--sp-sm) 0 var(--sp-sm);
+}
+
+.mission-brief-card {
+  margin-bottom: var(--sp-sm);
+  padding: var(--sp-md);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-medium);
+  background:
+    radial-gradient(
+      circle at 92% 12%,
+      rgba(34, 211, 238, 0.18),
+      transparent 36%
+    ),
+    var(--bg-card);
+}
+
+.mission-brief-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-sm);
+  margin-bottom: var(--sp-xs);
+}
+
+.mission-brief-code {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--accent-cyan);
+}
+
+.mission-brief-phase {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-tertiary);
+}
+
+.mission-brief-summary {
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+  margin-bottom: var(--sp-sm);
+}
+
+.mission-brief-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.mission-brief-tag {
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(34, 211, 238, 0.24);
+  background: rgba(34, 211, 238, 0.11);
+  color: var(--accent-cyan);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mission-guide-toolbar {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--sp-xs);
+  margin-bottom: var(--sp-sm);
+}
+
+.mission-guide-toolbar .btn-sm {
+  padding: 5px 8px;
+  font-size: 10px;
+}
+
+.mission-step-list {
+  list-style: none;
+  display: grid;
+  gap: 6px;
+  max-height: 190px;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.mission-step-item {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-sm);
+  background: var(--bg-card);
+  display: grid;
+  gap: 4px;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.mission-step-item:hover {
+  border-color: var(--border-strong);
+}
+
+.mission-step-item.is-complete {
+  border-color: rgba(52, 211, 153, 0.25);
+  background: rgba(52, 211, 153, 0.08);
+}
+
+.mission-step-item.is-next {
+  border-color: rgba(59, 130, 246, 0.35);
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.mission-step-item.is-applied {
+  border-color: rgba(34, 211, 238, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(34, 211, 238, 0.2);
+}
+
+.mission-step-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-xs);
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.mission-step-badge {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--text-tertiary);
+}
+
+.mission-step-meta {
+  display: flex;
+  gap: var(--sp-xs);
+}
+
+.mission-step-chip {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  padding: 1px 6px;
+  border-radius: var(--radius-full);
+  color: var(--text-secondary);
+  background: var(--bg-input);
+}
+
+.mission-step-note {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  line-height: 1.35;
+}
+
 /* ─── Command Buttons Grid ─── */
 .command-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--sp-sm);
+  margin-bottom: var(--sp-sm);
 }
 
 .cmd-btn {
@@ -1400,6 +1842,47 @@ body.three-panel-open .panel-telemetry.compact-log .telemetry-last-line {
 /* ─── Input Fields ─── */
 .input-group {
   margin-bottom: var(--sp-md);
+}
+
+.task-id-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--sp-xs);
+}
+
+.task-id-regenerate-btn {
+  align-self: stretch;
+  white-space: nowrap;
+}
+
+.task-id-meta {
+  margin-top: 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--sp-sm);
+}
+
+.task-id-toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+
+.task-id-toggle-label input {
+  accent-color: var(--accent-cyan);
+}
+
+.task-id-preview {
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .input-group label {
@@ -1508,6 +1991,13 @@ body.three-panel-open .panel-telemetry.compact-log .telemetry-last-line {
   font-size: 10px;
 }
 
+.command-log-left {
+  max-height: none;
+  height: 100%;
+  min-height: 0;
+  flex: 1;
+}
+
 .cmd-log-entry {
   padding: var(--sp-xxs) 0;
   border-bottom: 1px solid var(--border-subtle);
@@ -1569,6 +2059,14 @@ body.three-panel-open .panel-telemetry.compact-log .telemetry-last-line {
   border-radius: var(--radius-sm);
   font-size: 11px;
   min-height: 32px;
+}
+
+.pending-acks-left {
+  max-height: none;
+  height: 100%;
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
 }
 
 .pending-none {
@@ -1722,7 +2220,7 @@ body.three-panel-open .panel-telemetry.compact-log .telemetry-last-line {
   }
 
   .panel-topology {
-    max-height: 200px;
+    max-height: none;
   }
 
   .topology-visual {

--- a/web-sim/index.html
+++ b/web-sim/index.html
@@ -6,7 +6,7 @@
     <title>LSOAS — Lunar Mission Control</title>
     <meta
       name="description"
-      content="Lunar Surface Operations Autonomous Science Network — A school-level satellite communication simulation with NASA-inspired mission control interface."
+      content="Lunar Surface Operations Autonomous Science Network — A Chandrayaan-themed lunar mission control simulation for teaching swarm rover operations."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -113,74 +113,144 @@
         <span class="fleet-banner-value" id="fleet-avg-battery">100%</span>
       </div>
       <div class="fleet-banner-item">
+        <span class="fleet-banner-label">Average Solar</span>
+        <span class="fleet-banner-value" id="fleet-avg-solar">--</span>
+      </div>
+      <div class="fleet-banner-item">
+        <span class="fleet-banner-label">Average Risk</span>
+        <span class="fleet-banner-value" id="fleet-avg-risk">--</span>
+      </div>
+      <div class="fleet-banner-item">
         <span class="fleet-banner-label">Commands / ACKs</span>
         <span class="fleet-banner-value" id="fleet-command-ack">0 / 0</span>
+      </div>
+      <div class="fleet-banner-item">
+        <span class="fleet-banner-label">Mission Context</span>
+        <span class="fleet-banner-value" id="fleet-mission-context"
+          >CY3-ops · Step 1/3</span
+        >
       </div>
     </section>
 
     <!-- ─── Main Layout ─── -->
     <main id="main-grid">
-      <!-- ━━━ LEFT: Node Topology ━━━ -->
+      <!-- ━━━ LEFT: Operations Streams ━━━ -->
       <section class="panel panel-topology" id="panel-topology">
         <div class="panel-header">
-          <h2>Network Topology</h2>
-          <span class="badge badge-live" id="badge-nodes">4 Nodes</span>
+          <h2>Operations Streams</h2>
+          <span class="badge badge-live">3 Tabs</span>
         </div>
-        <div class="topology-visual" id="topology-visual">
-          <!-- Topology Canvas (SVG-based connection lines) -->
-          <svg
-            class="topology-lines"
-            id="topology-lines"
-            preserveAspectRatio="none"
-          ></svg>
-
-          <!-- Nodes... -->
-
-          <!-- Earth Node -->
-          <div class="topo-node" id="topo-earth" data-node="earth">
-            <div class="topo-node-ring">
-              <div class="topo-node-icon">🌍</div>
+        <div class="dropdown-stack left-dropdown-stack" id="left-dropdown-stack">
+          <section
+            class="dropdown-block is-open"
+            id="left-command-log-block"
+            data-accordion-group="left-orbital"
+            data-default-open="true"
+          >
+            <button class="dropdown-toggle" type="button" aria-expanded="true">
+              <span class="dropdown-title">Command Log</span>
+              <span class="dropdown-meta">Earth uplink stream</span>
+              <span class="dropdown-chevron" aria-hidden="true"></span>
+            </button>
+            <div class="dropdown-content">
+              <div class="command-log command-log-left" id="command-log">
+                <div class="feed-empty">
+                  <span>No commands sent yet</span>
+                </div>
+              </div>
             </div>
-            <span class="topo-node-label">Earth Station</span>
-            <span class="topo-node-state" id="earth-state">ONLINE</span>
-          </div>
+          </section>
 
-          <!-- Space Link Node -->
-          <div class="topo-node" id="topo-spacelink" data-node="spacelink">
-            <div class="topo-node-ring">
-              <div class="topo-node-icon">🛰️</div>
+          <section
+            class="dropdown-block"
+            id="left-pending-ack-block"
+            data-accordion-group="left-orbital"
+            data-default-open="false"
+          >
+            <button class="dropdown-toggle" type="button" aria-expanded="false">
+              <span class="dropdown-title">Pending ACKs</span>
+              <span class="pending-count" id="pending-count">0</span>
+              <span class="dropdown-chevron" aria-hidden="true"></span>
+            </button>
+            <div class="dropdown-content" hidden>
+              <div class="pending-acks pending-acks-left" id="pending-acks">
+                <span class="pending-none">No pending commands</span>
+              </div>
             </div>
-            <span class="topo-node-label">Space Link</span>
-            <span class="topo-node-state" id="spacelink-state">RELAY</span>
-          </div>
+          </section>
 
-          <!-- Rover Node -->
-          <div class="topo-node" id="topo-rover" data-node="rover">
-            <div class="topo-node-ring">
-              <div class="topo-node-icon">🤖</div>
+          <section
+            class="dropdown-block is-open"
+            id="left-topology-block"
+            data-accordion-group="left-orbital"
+            data-default-open="true"
+          >
+            <button class="dropdown-toggle" type="button" aria-expanded="true">
+              <span class="dropdown-title">Network Topology</span>
+              <span class="dropdown-meta">4 mission nodes</span>
+              <span class="dropdown-chevron" aria-hidden="true"></span>
+            </button>
+            <div class="dropdown-content">
+              <div class="topology-visual" id="topology-visual">
+                <!-- Topology Canvas (SVG-based connection lines) -->
+                <svg
+                  class="topology-lines"
+                  id="topology-lines"
+                  preserveAspectRatio="none"
+                ></svg>
+
+                <!-- Nodes... -->
+
+                <!-- Earth Node -->
+                <div class="topo-node" id="topo-earth" data-node="earth">
+                  <div class="topo-node-ring">
+                    <div class="topo-node-icon">🌍</div>
+                  </div>
+                  <span class="topo-node-label">Earth Station</span>
+                  <span class="topo-node-state" id="earth-state">ONLINE</span>
+                </div>
+
+                <!-- Space Link Node -->
+                <div class="topo-node" id="topo-spacelink" data-node="spacelink">
+                  <div class="topo-node-ring">
+                    <div class="topo-node-icon">🛰️</div>
+                  </div>
+                  <span class="topo-node-label">Space Link</span>
+                  <span class="topo-node-state" id="spacelink-state">RELAY</span>
+                </div>
+
+                <!-- Rover Node -->
+                <div class="topo-node" id="topo-rover" data-node="rover">
+                  <div class="topo-node-ring">
+                    <div class="topo-node-icon">🤖</div>
+                  </div>
+                  <span class="topo-node-label">Lunar Rover</span>
+                  <span class="topo-node-state" id="rover-state">IDLE</span>
+                </div>
+
+                <!-- Telemetry Monitor -->
+                <div class="topo-node" id="topo-telemetry" data-node="telemetry">
+                  <div class="topo-node-ring">
+                    <div class="topo-node-icon">📡</div>
+                  </div>
+                  <span class="topo-node-label">Telemetry</span>
+                  <span class="topo-node-state" id="telemetry-state"
+                    >LISTENING</span
+                  >
+                </div>
+              </div>
+
+              <!-- Signal Flow Indicators -->
+              <div class="signal-legend">
+                <div class="signal-legend-item">
+                  <span class="signal-arrow up">↑</span> Uplink (Cmd)
+                </div>
+                <div class="signal-legend-item">
+                  <span class="signal-arrow down">↓</span> Downlink (Tlm)
+                </div>
+              </div>
             </div>
-            <span class="topo-node-label">Lunar Rover</span>
-            <span class="topo-node-state" id="rover-state">IDLE</span>
-          </div>
-
-          <!-- Telemetry Monitor -->
-          <div class="topo-node" id="topo-telemetry" data-node="telemetry">
-            <div class="topo-node-ring">
-              <div class="topo-node-icon">📡</div>
-            </div>
-            <span class="topo-node-label">Telemetry</span>
-            <span class="topo-node-state" id="telemetry-state">LISTENING</span>
-          </div>
-        </div>
-
-        <!-- Signal Flow Indicators -->
-        <div class="signal-legend">
-          <div class="signal-legend-item">
-            <span class="signal-arrow up">↑</span> Uplink (Cmd)
-          </div>
-          <div class="signal-legend-item">
-            <span class="signal-arrow down">↓</span> Downlink (Tlm)
-          </div>
+          </section>
         </div>
       </section>
 
@@ -193,35 +263,68 @@
           </div>
         </div>
 
-        <!-- Fleet Status Grid -->
-        <div class="fleet-grid-panel" id="fleet-grid-panel">
-          <div class="fleet-grid-toolbar">
-            <span class="fleet-grid-summary" id="fleet-grid-summary"
-              >Showing 0 of 0 rovers</span
-            >
-            <button class="btn-sm" id="btn-toggle-fleet-scope">Show All</button>
-          </div>
-          <div class="fleet-grid" id="fleet-grid" aria-live="polite">
-            <div class="feed-empty">
-              <span class="feed-empty-icon">🤖</span>
-              <span>Awaiting fleet telemetry…</span>
-            </div>
-          </div>
-          <div class="fleet-hover-card" id="fleet-hover-card" hidden></div>
-        </div>
-
-        <!-- Telemetry Feed -->
-        <div class="telemetry-feed" id="telemetry-feed">
-          <div class="feed-empty">
-            <span class="feed-empty-icon">📡</span>
-            <span>Awaiting telemetry…</span>
-          </div>
-        </div>
-        <div class="telemetry-last-line" id="telemetry-last-line">
-          <span class="telemetry-last-label">Last Log</span>
-          <span class="telemetry-last-value" id="telemetry-last-value"
-            >Awaiting telemetry…</span
+        <div
+          class="dropdown-stack telemetry-dropdown-stack"
+          id="telemetry-dropdown-stack"
+        >
+          <section
+            class="dropdown-block is-open"
+            id="telemetry-fleet-block"
+            data-accordion-group="telemetry-orbital"
+            data-default-open="true"
           >
+            <button class="dropdown-toggle" type="button" aria-expanded="true">
+              <span class="dropdown-title">Fleet Status</span>
+              <span class="dropdown-meta">Rover cards and pinning</span>
+              <span class="dropdown-chevron" aria-hidden="true"></span>
+            </button>
+            <div class="dropdown-content">
+              <div class="fleet-grid-panel" id="fleet-grid-panel">
+                <div class="fleet-grid-toolbar">
+                  <span class="fleet-grid-summary" id="fleet-grid-summary"
+                    >Showing 0 of 0 rovers</span
+                  >
+                  <button class="btn-sm" id="btn-toggle-fleet-scope">
+                    Show All
+                  </button>
+                </div>
+                <div class="fleet-grid" id="fleet-grid" aria-live="polite">
+                  <div class="feed-empty">
+                    <span class="feed-empty-icon">🤖</span>
+                    <span>Awaiting fleet telemetry…</span>
+                  </div>
+                </div>
+                <div class="fleet-hover-card" id="fleet-hover-card" hidden></div>
+              </div>
+            </div>
+          </section>
+
+          <section
+            class="dropdown-block is-open"
+            id="telemetry-stream-block"
+            data-accordion-group="telemetry-orbital"
+            data-default-open="true"
+          >
+            <button class="dropdown-toggle" type="button" aria-expanded="true">
+              <span class="dropdown-title">Telemetry Stream</span>
+              <span class="dropdown-meta">Live downlink events</span>
+              <span class="dropdown-chevron" aria-hidden="true"></span>
+            </button>
+            <div class="dropdown-content">
+              <div class="telemetry-feed" id="telemetry-feed">
+                <div class="feed-empty">
+                  <span class="feed-empty-icon">📡</span>
+                  <span>Awaiting telemetry…</span>
+                </div>
+              </div>
+              <div class="telemetry-last-line" id="telemetry-last-line">
+                <span class="telemetry-last-label">Last Log</span>
+                <span class="telemetry-last-value" id="telemetry-last-value"
+                  >Awaiting telemetry…</span
+                >
+              </div>
+            </div>
+          </section>
         </div>
       </section>
 
@@ -278,154 +381,244 @@
           <span class="badge badge-earth">Earth Station</span>
         </div>
 
-        <!-- Quick Commands -->
-        <div class="command-section">
-          <h3>Quick Commands</h3>
-          <div class="command-grid">
-            <button class="cmd-btn cmd-start" id="cmd-start-task">
-              <span class="cmd-icon">▶</span>
-              <span class="cmd-label">Start Task</span>
+        <div class="dropdown-stack right-dropdown-stack" id="right-dropdown-stack">
+          <section
+            class="dropdown-block is-open"
+            id="mission-controls-block"
+            data-accordion-group="right-controls"
+          >
+            <button class="dropdown-toggle" type="button" aria-expanded="true">
+              <span class="dropdown-title">Mission Controls</span>
+              <span class="dropdown-meta">Guide, task setup, and dispatch</span>
+              <span class="dropdown-chevron" aria-hidden="true"></span>
             </button>
-            <button class="cmd-btn cmd-abort" id="cmd-abort">
-              <span class="cmd-icon">⏹</span>
-              <span class="cmd-label">Abort</span>
-            </button>
-            <button class="cmd-btn cmd-safe" id="cmd-go-safe">
-              <span class="cmd-icon">🛡</span>
-              <span class="cmd-label">Safe Mode</span>
-            </button>
-            <button class="cmd-btn cmd-reset" id="cmd-reset">
-              <span class="cmd-icon">↻</span>
-              <span class="cmd-label">Reset</span>
-            </button>
-          </div>
-        </div>
+            <div class="dropdown-content">
+              <div class="command-section command-section-inner">
+                <div class="control-subheading">Quick Commands</div>
+                <div class="command-grid">
+                  <button class="cmd-btn cmd-start" id="cmd-start-task">
+                    <span class="cmd-icon">▶</span>
+                    <span class="cmd-label">Start Task</span>
+                  </button>
+                  <button class="cmd-btn cmd-abort" id="cmd-abort">
+                    <span class="cmd-icon">⏹</span>
+                    <span class="cmd-label">Abort</span>
+                  </button>
+                  <button class="cmd-btn cmd-safe" id="cmd-go-safe">
+                    <span class="cmd-icon">🛡</span>
+                    <span class="cmd-label">Safe Mode</span>
+                  </button>
+                  <button class="cmd-btn cmd-reset" id="cmd-reset">
+                    <span class="cmd-icon">↻</span>
+                    <span class="cmd-label">Reset</span>
+                  </button>
+                </div>
 
-        <!-- Task ID Input -->
-        <div class="command-section">
-          <h3>Task Configuration</h3>
-          <div class="input-group">
-            <label for="rover-target-select">Target Rover</label>
-            <select id="rover-target-select" class="input-field select-field">
-              <option value="auto">Auto-Select (Best Rover)</option>
-            </select>
-          </div>
-          <div class="input-group">
-            <label for="task-id-input">Task ID</label>
-            <input
-              type="text"
-              id="task-id-input"
-              class="input-field"
-              placeholder="e.g. CY3-SCI-001"
-              value="CY3-SCI-001"
-            />
-          </div>
-          <div class="input-group">
-            <label for="task-type-select">Task Type</label>
-            <select id="task-type-select" class="input-field select-field">
-              <option value="movement">Movement/Traverse</option>
-              <option value="science">Science Investigation</option>
-              <option value="digging">Digging/Drilling</option>
-              <option value="pushing">Pushing/Regolith Handling</option>
-              <option value="photo">Photo/Imaging Survey</option>
-              <option value="sample-handling">Sample Handling/Transfer</option>
-            </select>
-          </div>
-          <div class="input-group">
-            <label for="task-difficulty-select">Difficulty</label>
-            <select id="task-difficulty-select" class="input-field select-field">
-              <option value="L1">L1 - Very Easy</option>
-              <option value="L2" selected>L2 - Easy</option>
-              <option value="L3">L3 - Moderate</option>
-              <option value="L4">L4 - Hard</option>
-              <option value="L5">L5 - Extreme</option>
-            </select>
-          </div>
-        </div>
+                <div class="control-subheading">Task Configuration</div>
+                <div class="input-group">
+                  <label for="rover-target-select">Target Rover</label>
+                  <select id="rover-target-select" class="input-field select-field">
+                    <option value="auto">Auto-Select (Best Rover)</option>
+                  </select>
+                </div>
+                <div class="input-group">
+                  <label for="task-id-input">Task ID</label>
+                  <div class="task-id-row">
+                    <input
+                      type="text"
+                      id="task-id-input"
+                      class="input-field"
+                      placeholder="e.g. CY3-SCI-L2-001"
+                      value="CY3-SCI-L2-001"
+                    />
+                    <button
+                      class="btn-sm task-id-regenerate-btn"
+                      id="task-id-regenerate-btn"
+                      type="button"
+                    >
+                      Regenerate
+                    </button>
+                  </div>
+                  <div class="task-id-meta">
+                    <label class="task-id-toggle-label" for="task-id-auto-toggle">
+                      <input type="checkbox" id="task-id-auto-toggle" checked />
+                      Auto-generate
+                    </label>
+                    <span class="task-id-preview" id="task-id-preview"></span>
+                  </div>
+                </div>
+                <div class="input-group">
+                  <label for="task-type-select">Task Type</label>
+                  <select id="task-type-select" class="input-field select-field">
+                    <option value="movement">Movement/Traverse</option>
+                    <option value="science">Science Investigation</option>
+                    <option value="digging">Digging/Drilling</option>
+                    <option value="pushing">Pushing/Regolith Handling</option>
+                    <option value="photo">Photo/Imaging Survey</option>
+                    <option value="sample-handling">Sample Handling/Transfer</option>
+                  </select>
+                </div>
+                <div class="input-group">
+                  <label for="task-difficulty-select">Difficulty</label>
+                  <select
+                    id="task-difficulty-select"
+                    class="input-field select-field"
+                  >
+                    <option value="L1">L1 - Very Easy</option>
+                    <option value="L2" selected>L2 - Easy</option>
+                    <option value="L3">L3 - Moderate</option>
+                    <option value="L4">L4 - Hard</option>
+                    <option value="L5">L5 - Extreme</option>
+                  </select>
+                </div>
+                <div class="input-group">
+                  <label for="target-site-input">Target Site (optional)</label>
+                  <input
+                    type="text"
+                    id="target-site-input"
+                    class="input-field"
+                    placeholder="e.g. Shiv Shakti Point Sector-A"
+                  />
+                </div>
 
-        <!-- Space Link Config -->
-        <div class="command-section">
-          <h3>Space Link Parameters</h3>
-          <div class="input-group">
-            <label for="latency-slider"
-              >Base Latency
-              <span class="param-value" id="latency-value">1.3s</span></label
-            >
-            <input
-              type="range"
-              id="latency-slider"
-              class="range-input"
-              min="0"
-              max="5"
-              step="0.1"
-              value="1.3"
-            />
-          </div>
-          <div class="input-group">
-            <label for="jitter-slider"
-              >Jitter
-              <span class="param-value" id="jitter-value">±0.2s</span></label
-            >
-            <input
-              type="range"
-              id="jitter-slider"
-              class="range-input"
-              min="0"
-              max="2"
-              step="0.05"
-              value="0.2"
-            />
-          </div>
-          <div class="input-group">
-            <label for="drop-slider"
-              >Drop Rate
-              <span class="param-value" id="drop-value">5%</span></label
-            >
-            <input
-              type="range"
-              id="drop-slider"
-              class="range-input"
-              min="0"
-              max="50"
-              step="1"
-              value="5"
-            />
-          </div>
-          <div class="input-group">
-            <label for="fault-slider"
-              >Risk Bias
-              <span class="param-value" id="fault-prob-value">0%</span></label
-            >
-            <input
-              type="range"
-              id="fault-slider"
-              class="range-input"
-              min="-20"
-              max="20"
-              step="1"
-              value="0"
-            />
-          </div>
-        </div>
-
-        <!-- Command Log -->
-        <div class="command-section">
-          <h3>Command Log</h3>
-          <div class="command-log" id="command-log">
-            <div class="feed-empty">
-              <span>No commands sent yet</span>
+                <section
+                  class="dropdown-block nested-dropdown-block"
+                  id="advanced-controls-block"
+                >
+                  <button
+                    class="dropdown-toggle"
+                    type="button"
+                    aria-expanded="false"
+                  >
+                    <span class="dropdown-title">Advanced Controls</span>
+                    <span class="dropdown-meta"
+                      >Fine-grained link and risk tuning</span
+                    >
+                    <span class="dropdown-chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="dropdown-content" hidden>
+                    <div class="input-group">
+                      <label for="latency-slider"
+                        >Base Latency
+                        <span class="param-value" id="latency-value">1.3s</span></label
+                      >
+                      <input
+                        type="range"
+                        id="latency-slider"
+                        class="range-input"
+                        min="0"
+                        max="5"
+                        step="0.1"
+                        value="1.3"
+                      />
+                    </div>
+                    <div class="input-group">
+                      <label for="jitter-slider"
+                        >Jitter
+                        <span class="param-value" id="jitter-value"
+                          >±0.2s</span
+                        ></label
+                      >
+                      <input
+                        type="range"
+                        id="jitter-slider"
+                        class="range-input"
+                        min="0"
+                        max="2"
+                        step="0.05"
+                        value="0.2"
+                      />
+                    </div>
+                    <div class="input-group">
+                      <label for="drop-slider"
+                        >Drop Rate
+                        <span class="param-value" id="drop-value">5%</span></label
+                      >
+                      <input
+                        type="range"
+                        id="drop-slider"
+                        class="range-input"
+                        min="0"
+                        max="50"
+                        step="1"
+                        value="5"
+                      />
+                    </div>
+                    <div class="input-group">
+                      <label for="fault-slider"
+                        >Risk Bias
+                        <span class="param-value" id="fault-prob-value">0%</span></label
+                      >
+                      <input
+                        type="range"
+                        id="fault-slider"
+                        class="range-input"
+                        min="-20"
+                        max="20"
+                        step="1"
+                        value="0"
+                      />
+                    </div>
+                  </div>
+                </section>
+              </div>
             </div>
-          </div>
-        </div>
+          </section>
 
-        <!-- Pending ACKs -->
-        <div class="command-section">
-          <h3>
-            Pending ACKs <span class="pending-count" id="pending-count">0</span>
-          </h3>
-          <div class="pending-acks" id="pending-acks">
-            <span class="pending-none">No pending commands</span>
-          </div>
+          <section
+            class="dropdown-block"
+            id="mission-explanation-block"
+            data-accordion-group="right-controls"
+          >
+            <button class="dropdown-toggle" type="button" aria-expanded="false">
+              <span class="dropdown-title">Mission Explanation</span>
+              <span class="dropdown-meta">Theme and payload context</span>
+              <span class="dropdown-chevron" aria-hidden="true"></span>
+            </button>
+            <div class="dropdown-content" hidden>
+              <div class="command-section command-section-inner">
+                <div class="input-group">
+                  <label for="mission-preset-select">Mission Preset</label>
+                  <select id="mission-preset-select" class="input-field select-field">
+                    <option value="cy3-pragyan" selected>
+                      Chandrayaan-3 Pragyan Surface Ops
+                    </option>
+                    <option value="cy4-sample-return">
+                      Chandrayaan-4 Sample Return Chain
+                    </option>
+                    <option value="lupex-polar-ice">LUPEX Polar Ice Prospecting</option>
+                    <option value="cy-future-base">
+                      Future Chandrayaan Base Build (Teaching Scenario)
+                    </option>
+                  </select>
+                </div>
+                <article class="mission-brief-card" id="mission-brief-card">
+                  <div class="mission-brief-head">
+                    <span class="mission-brief-code" id="mission-brief-code">CY3</span>
+                    <span class="mission-brief-phase" id="mission-brief-phase"
+                      >CY3-ops</span
+                    >
+                  </div>
+                  <p class="mission-brief-summary" id="mission-brief-summary">
+                    Pragyan-style near-surface traverse and in-situ science sequence.
+                  </p>
+                  <div class="mission-brief-tags" id="mission-brief-tags"></div>
+                </article>
+                <div class="mission-guide-toolbar">
+                  <button class="btn-sm" id="mission-apply-btn" type="button">
+                    Apply Preset
+                  </button>
+                  <button class="btn-sm" id="mission-next-step-btn" type="button">
+                    Use Next Step
+                  </button>
+                  <button class="btn-sm" id="mission-reset-btn" type="button">
+                    Reset Guide
+                  </button>
+                </div>
+                <ol class="mission-step-list" id="mission-step-list"></ol>
+              </div>
+            </div>
+          </section>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Problem
`develop` now contains the completed Chandrayaan teaching-dashboard redesign and Phase 1 task/ops UX, but `main` does not yet include these changes.

## What changed
- Releases the full Phase 1 Chandrayaan mission-teaching dashboard redesign from `develop` into `main`.
- Adds reworked command-and-telemetry operations layout, orbital-view responsive collapse behavior, and improved panel state handling.
- Includes task configuration UX updates, mission explanation/preset interactions, and auto-generated but editable task IDs.
- Includes README refresh with updated dashboard screenshots.

## Why this design
- Keeps the repo on a disciplined `develop -> main` release workflow.
- Packages all validated Phase 1 work into a single formal baseline (`v1.0.0`) suitable for demos, onboarding, and roadmap milestone closure.

## Testing evidence
- Functional UI verification performed throughout Phase 1 workstream (panel collapse/expand behavior, orbital-view transitions, scroll behavior, and control persistence).
- Branch-level integration validation via merged feature PRs into `develop`, then release promotion to `main`.

## Migration notes
- No breaking API/runtime migration required for consumers.
- Operational baseline now assumes the Chandrayaan teaching dashboard behavior and updated README visual references.

## Superseded issue mapping (old -> new)
- Legacy generic roadmap tracking superseded by Chandrayaan v2/teaching-dashboard implementation track merged into `develop`.
- This release PR marks the end of Phase 1 delivery and establishes `v1.0.0` as the first formal release baseline.

## Phase 1 milestone
This PR marks **Phase 1 complete** and requests release promotion to `main` as **v1.0.0**.
