### PR TITLE
chore: productionize release gating and public repo hygiene

### DIFF
--- a/.agent/artifacts/issue-32-walkthrough.md
+++ b/.agent/artifacts/issue-32-walkthrough.md
@@ -8,10 +8,10 @@ Implemented a bug-fix upgrade for fleet telemetry visibility and interaction in 
 - Added compact 3D hover-mode status cards for rover quick inspection.
 
 ## Files Updated
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/web-sim/index.html`
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/web-sim/index.css`
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/web-sim/app.js`
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/.agent/artifacts/issue-32-implementation-plan.md`
+- `web-sim/index.html`
+- `web-sim/index.css`
+- `web-sim/app.js`
+- `.agent/artifacts/issue-32-implementation-plan.md`
 
 ## What Was Implemented
 

--- a/.agent/artifacts/issues-12-13-walkthrough.md
+++ b/.agent/artifacts/issues-12-13-walkthrough.md
@@ -5,9 +5,9 @@
 - Added an integration-style multi-rover command-flow test covering auto assignment, rover state transitions, and ACK routing.
 
 ## Files Added
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/lunar_ops/rover_ws/src/rover_core/test/_helpers.py`
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/lunar_ops/rover_ws/src/rover_core/test/test_task_assignment.py`
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/lunar_ops/rover_ws/src/rover_core/test/test_fleet_integration.py`
+- `lunar_ops/rover_ws/src/rover_core/test/_helpers.py`
+- `lunar_ops/rover_ws/src/rover_core/test/test_task_assignment.py`
+- `lunar_ops/rover_ws/src/rover_core/test/test_fleet_integration.py`
 
 ## Issue #12: Unit tests for task assignment algorithm
 

--- a/.agent/artifacts/issues-9-10-11-walkthrough.md
+++ b/.agent/artifacts/issues-9-10-11-walkthrough.md
@@ -4,9 +4,9 @@
 Updated the web dashboard to support fleet-level mission operations UI.
 
 Files changed:
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/web-sim/index.html`
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/web-sim/index.css`
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/web-sim/app.js`
+- `web-sim/index.html`
+- `web-sim/index.css`
+- `web-sim/app.js`
 
 ## Issue #9: Fleet Status Grid
 

--- a/.agent/workflows/branch-and-pr.md
+++ b/.agent/workflows/branch-and-pr.md
@@ -6,6 +6,8 @@ description: How to create a feature branch, commit changes, and raise PRs with 
 
 Follow this process for every feature, fix, or docs change.
 
+Prerequisite: run `gh auth login` once on your machine before using `gh` commands.
+
 ## Branch and environment model
 
 - `dev`: integration branch for daily development (deploys to Dev environment)
@@ -73,8 +75,7 @@ git push -u origin codex/<branch-name>
 ## 6. Open PR to dev
 
 ```bash
-export GH_CONFIG_DIR=/Users/varma/.gh_config
-
+gh auth status || gh auth login
 gh pr create \
   -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network \
   --base dev \

--- a/.agent/workflows/compare-issues.md
+++ b/.agent/workflows/compare-issues.md
@@ -6,6 +6,8 @@ description: Compare two GitHub issues — scope, complexity, overlap, and recom
 
 This workflow fetches two GitHub issues and provides a side-by-side comparison.
 
+Prerequisite: run `gh auth login` once on your machine before using `gh` commands.
+
 ## Steps
 
 // turbo-all
@@ -13,11 +15,11 @@ This workflow fetches two GitHub issues and provides a side-by-side comparison.
 1. **Fetch both issues** from GitHub:
 
    ```
-   export GH_CONFIG_DIR=/Users/varma/.gh_config && gh issue view <ISSUE_A> -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network --json title,body,labels,milestone
+   gh issue view <ISSUE_A> -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network --json title,body,labels,milestone
    ```
 
    ```
-   export GH_CONFIG_DIR=/Users/varma/.gh_config && gh issue view <ISSUE_B> -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network --json title,body,labels,milestone
+   gh issue view <ISSUE_B> -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network --json title,body,labels,milestone
    ```
 
    Replace `<ISSUE_A>` and `<ISSUE_B>` with the two issue numbers provided by the user.

--- a/.agent/workflows/explain-issue.md
+++ b/.agent/workflows/explain-issue.md
@@ -6,6 +6,8 @@ description: Explain a GitHub issue in detail — what it involves, why it matte
 
 This workflow fetches a GitHub issue and provides a comprehensive explanation.
 
+Prerequisite: run `gh auth login` once on your machine before using `gh` commands.
+
 ## Steps
 
 // turbo-all
@@ -13,7 +15,7 @@ This workflow fetches a GitHub issue and provides a comprehensive explanation.
 1. **Fetch the issue** from GitHub:
 
    ```
-   export GH_CONFIG_DIR=/Users/varma/.gh_config && gh issue view <ISSUE_NUMBER> -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network --json title,body,labels,milestone,assignees,state
+   gh issue view <ISSUE_NUMBER> -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network --json title,body,labels,milestone,assignees,state
    ```
 
    Replace `<ISSUE_NUMBER>` with the issue number provided by the user.

--- a/.agent/workflows/implement-issue.md
+++ b/.agent/workflows/implement-issue.md
@@ -6,6 +6,8 @@ description: Implement a GitHub issue from the LSOAS roadmap using dev, staging,
 
 This workflow fetches a GitHub issue and implements it end-to-end on a `codex/*` branch.
 
+Prerequisite: run `gh auth login` once on your machine before using `gh` commands.
+
 ## Steps
 
 // turbo-all
@@ -13,7 +15,7 @@ This workflow fetches a GitHub issue and implements it end-to-end on a `codex/*`
 1. **Fetch the issue** from GitHub:
 
    ```bash
-   export GH_CONFIG_DIR=/Users/varma/.gh_config
+   gh auth status || gh auth login
    gh issue view <ISSUE_NUMBER> \
      -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network \
      --json title,body,labels,milestone,state
@@ -59,7 +61,6 @@ This workflow fetches a GitHub issue and implements it end-to-end on a `codex/*`
 8. **Create PR to dev**:
 
    ```bash
-   export GH_CONFIG_DIR=/Users/varma/.gh_config
    gh pr create \
      -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network \
      --base dev \
@@ -71,7 +72,6 @@ This workflow fetches a GitHub issue and implements it end-to-end on a `codex/*`
 9. **Move issue to In Review** on project board:
 
    ```bash
-   export GH_CONFIG_DIR=/Users/varma/.gh_config
    gh project item-edit \
      --project-id <PROJECT_ID> \
      --id <ITEM_ID> \

--- a/.agent/workflows/release.md
+++ b/.agent/workflows/release.md
@@ -6,6 +6,8 @@ description: End-to-end release workflow using dev -> staging -> main(prod), sem
 
 Use this workflow for every formal release (`vX.Y.Z`).
 
+Prerequisite: run `gh auth login` once on your machine before using `gh` commands.
+
 ## Environment and branch mapping
 
 - `dev` branch -> Dev environment (playground/integration)
@@ -126,7 +128,6 @@ PRBODY
 Open PR:
 
 ```bash
-export GH_CONFIG_DIR=/Users/varma/.gh_config
 gh pr create \
   -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network \
   --base staging \
@@ -140,7 +141,6 @@ gh pr create \
 On the `dev -> staging` PR:
 
 ```bash
-export GH_CONFIG_DIR=/Users/varma/.gh_config
 gh pr view <STAGE_PR_NUMBER> \
   -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network \
   --json mergeable,mergeStateStatus,statusCheckRollup
@@ -156,7 +156,6 @@ Required to pass before merge:
 Merge gate PR:
 
 ```bash
-export GH_CONFIG_DIR=/Users/varma/.gh_config
 gh pr merge <STAGE_PR_NUMBER> \
   -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network \
   --merge --delete-branch=false
@@ -198,7 +197,6 @@ PRBODY
 Open PR:
 
 ```bash
-export GH_CONFIG_DIR=/Users/varma/.gh_config
 gh pr create \
   -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network \
   --base main \
@@ -210,7 +208,6 @@ gh pr create \
 Verify and merge:
 
 ```bash
-export GH_CONFIG_DIR=/Users/varma/.gh_config
 gh pr view <PROD_PR_NUMBER> \
   -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network \
   --json mergeable,mergeStateStatus,statusCheckRollup
@@ -249,7 +246,6 @@ cat > /tmp/release_notes.md <<'NOTES'
 - Promoted via dev -> staging -> main
 NOTES
 
-export GH_CONFIG_DIR=/Users/varma/.gh_config
 gh release create <VERSION> \
   -R SumanthVarma798/Lunar-Surface-Operations-Autonomous-Science-Network \
   --target main \

--- a/.github/workflows/deploy-environments.yml
+++ b/.github/workflows/deploy-environments.yml
@@ -1,0 +1,116 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# LSOAS Environment Promotion Pipeline
+# Uses GitHub Environments for gated deployments:
+# dev (playground) -> staging (prod replica) -> production
+# ─────────────────────────────────────────────────────────────────────────────
+name: CD — Environment Promotion Gates
+
+on:
+  push:
+    branches: [dev, staging, main]
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: "Environment to deploy"
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - production
+      ref:
+        description: "Optional git ref (branch, tag, or SHA)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-dev:
+    name: Deploy to Dev
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'dev')
+    runs-on: ubuntu-latest
+    environment:
+      name: dev
+      url: ${{ vars.DEV_ENV_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Deployment summary
+        run: |
+          echo "Environment: dev" >> $GITHUB_STEP_SUMMARY
+          echo "Ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "Commit: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Health smoke
+        run: |
+          cd web-sim
+          python3 -m http.server 8080 &
+          SERVER_PID=$!
+          sleep 2
+          CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/)
+          test "$CODE" = "200"
+          kill $SERVER_PID
+
+  deploy-staging:
+    name: Deploy to Staging
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/staging') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'staging')
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+      url: ${{ vars.STAGING_ENV_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Deployment summary
+        run: |
+          echo "Environment: staging" >> $GITHUB_STEP_SUMMARY
+          echo "Ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "Commit: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "This environment should mirror production for release gating." >> $GITHUB_STEP_SUMMARY
+
+      - name: Verify build artifacts
+        run: |
+          test -f web-sim/index.html
+          test -f lunar_ops/rover_ws/src/rover_core/rover_core/rover_node.py
+
+  deploy-production:
+    name: Deploy to Production
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target_environment == 'production')
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ vars.PRODUCTION_ENV_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Deployment summary
+        run: |
+          echo "Environment: production" >> $GITHUB_STEP_SUMMARY
+          echo "Ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "Commit: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "Production deploys should only happen from staging-approved state." >> $GITHUB_STEP_SUMMARY
+
+      - name: Final sanity checks
+        run: |
+          test -f README.md
+          test -f .github/workflows/ci.yml
+          test -f .github/workflows/deploy-environments.yml

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Final predicted fault probability is context-aware and clamped to `0%..60%` usin
 
 Task catalog source (machine-readable):
 
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/web-sim/assets/chandrayaan_task_catalog.json`
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/lunar_ops/rover_ws/src/rover_core/rover_core/chandrayaan_task_catalog.json`
+- `web-sim/assets/chandrayaan_task_catalog.json`
+- `lunar_ops/rover_ws/src/rover_core/rover_core/chandrayaan_task_catalog.json`
 
 ---
 
@@ -90,13 +90,13 @@ Core runtime nodes/layers:
 
 Task-model utility module:
 
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/lunar_ops/rover_ws/src/rover_core/rover_core/task_model.py`
+- `lunar_ops/rover_ws/src/rover_core/rover_core/task_model.py`
 
 Supporting docs:
 
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/docs/chandrayaan_v2_architecture.md`
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/docs/chandrayaan_v2_migration.md`
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/docs/roadmap.md`
+- `docs/chandrayaan_v2_architecture.md`
+- `docs/chandrayaan_v2_migration.md`
+- `docs/roadmap.md`
 
 ---
 
@@ -163,7 +163,7 @@ Dashboard task IDs are auto-generated (mission + task type + difficulty + sequen
 ### ROS 2 Simulation
 
 ```bash
-cd /Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network
+cd Lunar-Surface-Operations-Autonomous-Science-Network
 make build
 make test-space-link
 make test-telemetry
@@ -244,6 +244,16 @@ Environment mapping:
 
 CI triggers on `dev`, `staging`, and `main`.
 
+GitHub Environments are used for gated promotion:
+
+- `dev` environment for playground/integration deploys
+- `staging` environment as production replica for validation/sign-off
+- `production` environment for final releases from `main`
+
+Deployment workflow file:
+
+- `.github/workflows/deploy-environments.yml`
+
 ---
 
 ## Roadmap Status
@@ -272,7 +282,7 @@ Milestone: `Phase 2: Chandrayaan Teaching & Base Operations`
 Run core unit/integration tests:
 
 ```bash
-pytest -q /Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/lunar_ops/rover_ws/src/rover_core/test
+pytest -q lunar_ops/rover_ws/src/rover_core/test
 ```
 
 Expected coverage targets for v2 scope:
@@ -286,7 +296,7 @@ Expected coverage targets for v2 scope:
 
 Detailed testing guide:
 
-- `/Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/docs/chandrayaan_v2_testing.md`
+- `docs/chandrayaan_v2_testing.md`
 
 ---
 

--- a/lunar_ops/docs/implementation_reference.md
+++ b/lunar_ops/docs/implementation_reference.md
@@ -2,10 +2,10 @@
 
 ## Files Modified
 
-### [`rover_node.py`](file:///Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/lunar_ops/rover_ws/src/rover_core/rover_core/rover_node.py)
+### [`rover_node.py`](../rover_ws/src/rover_core/rover_core/rover_node.py)
 **Complete rewrite** from puppetry to autonomy
 
-### [`earth_node.py`](file:///Users/varma/Desktop/workspace/Lunar-Surface-Operations-Autonomous-Science-Network/lunar_ops/rover_ws/src/rover_core/rover_core/earth_node.py)
+### [`earth_node.py`](../rover_ws/src/rover_core/rover_core/earth_node.py)
 **Added interactive command interface** for operator control
 
 ## State Machine Implementation


### PR DESCRIPTION
## Problem
Release governance and repository hygiene needed production-grade polish for a public-facing project:
- Environment-gated release flow needed to be operational (not only documented)
- Public docs still had local machine paths and user-specific config hints
- Stale branches cluttered the public repository

## What changed (in this PR)
- Added GitHub Environments deployment workflow:
  - `.github/workflows/deploy-environments.yml`
  - maps branch promotions to environments: `dev`, `staging`, `production`
- Sanitized personal/local references from public docs and workflow guides:
  - `README.md`
  - `.agent/workflows/*.md` (auth guidance switched to generic `gh auth login`)
  - `lunar_ops/docs/implementation_reference.md`
  - `.agent/artifacts/*` path cleanup
- Improved README with explicit environment-gated deployment section.

## What changed (already applied on GitHub)
- Created and configured environments:
  - `dev` (branch policy)
  - `staging` (required reviewer + branch policy)
  - `production` (required reviewer + branch policy)
- Updated repository About description and homepage.
- Pruned stale remote branches; kept only active long-lived branches (`main`, `dev`, `staging`) plus active feature work.

## Why this design
- Aligns code, workflows, and GitHub runtime policy with a professional SDLC:
  - Dev playground
  - Staging as production replica gate
  - Production promotion only after staging validation
- Removes machine-specific leakage from public documentation.
- Keeps branch space clean and easier to navigate for contributors.

## Testing evidence
- Verified personal path/config leaks are removed from tracked files.
- Verified environment workflow YAML renders correctly.
- Verified environment objects exist and include protection rules via GitHub API.

## Migration notes
- `develop` is legacy and no longer part of the active promotion path.
- Active promotion path is now `codex/* -> dev -> staging -> main`.

## Superseded issue mapping (old -> new)
- Old `develop -> main` release flow superseded by environment-gated `dev -> staging -> main` flow.
