### PR TITLE
ci: auto-deploy web simulation on release

### DIFF
--- a/.agent/workflows/release.md
+++ b/.agent/workflows/release.md
@@ -253,6 +253,8 @@ gh release create <VERSION> \
   --notes-file /tmp/release_notes.md
 ```
 
+Publishing the GitHub release triggers `.github/workflows/release-web-sim.yml`, which refreshes hosted `web-sim/` deployments (GitHub Pages by default, plus Cloudflare Pages when configured).
+
 ## 10. Roadmap and milestone updates
 
 After production release:

--- a/.github/workflows/release-web-sim.yml
+++ b/.github/workflows/release-web-sim.yml
@@ -1,0 +1,92 @@
+name: Release - Deploy Web Simulation
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to deploy (branch, tag, or SHA)"
+        required: false
+        default: "main"
+        type: string
+      deploy_target:
+        description: "Where to deploy web-sim"
+        required: true
+        default: "both"
+        type: choice
+        options:
+          - github-pages
+          - cloudflare
+          - both
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: release-web-sim-${{ github.event.release.tag_name || github.ref_name || 'manual' }}
+  cancel-in-progress: true
+
+env:
+  WEB_SIM_DIR: web-sim
+
+jobs:
+  prepare-artifact:
+    name: Prepare web-sim artifact
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref || 'main' }}
+
+      - name: Validate static app files
+        run: |
+          test -f "${WEB_SIM_DIR}/index.html"
+          test -f "${WEB_SIM_DIR}/app.js"
+          test -f "${WEB_SIM_DIR}/simulation.js"
+          test -f "${WEB_SIM_DIR}/index.css"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ env.WEB_SIM_DIR }}
+
+  deploy-github-pages:
+    name: Deploy to GitHub Pages
+    if: >
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' &&
+      (inputs.deploy_target == 'github-pages' || inputs.deploy_target == 'both'))
+    needs: prepare-artifact
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+
+  deploy-cloudflare-pages:
+    name: Deploy to Cloudflare Pages
+    if: >
+      (github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' &&
+      (inputs.deploy_target == 'cloudflare' || inputs.deploy_target == 'both')))
+      && secrets.CLOUDFLARE_API_TOKEN != ''
+      && secrets.CLOUDFLARE_ACCOUNT_ID != ''
+      && secrets.CLOUDFLARE_PAGES_PROJECT != ''
+    needs: prepare-artifact
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref || 'main' }}
+
+      - name: Deploy static site with Wrangler
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy web-sim --project-name ${{ secrets.CLOUDFLARE_PAGES_PROJECT }} --branch production

--- a/README.md
+++ b/README.md
@@ -256,6 +256,32 @@ Deployment workflow file:
 
 ---
 
+## Hosted Deployment (Auto on Release)
+
+Web simulation hosting is automated by:
+
+- `.github/workflows/release-web-sim.yml`
+
+Behavior:
+
+- On every GitHub Release (`published`), the workflow deploys `web-sim/` to GitHub Pages.
+- If Cloudflare secrets are configured, the same release also deploys to Cloudflare Pages.
+- You can also run it manually via `workflow_dispatch`.
+
+One-time setup:
+
+1. In repository settings, set GitHub Pages source to **GitHub Actions**.
+2. Optional Cloudflare setup (repository secrets):
+   - `CLOUDFLARE_API_TOKEN`
+   - `CLOUDFLARE_ACCOUNT_ID`
+   - `CLOUDFLARE_PAGES_PROJECT`
+
+Result:
+
+- Creating a release refreshes the hosted simulation automatically.
+
+---
+
 ## Agent Workflows
 
 This repository includes a committed agent playbook so local clones and forks behave consistently.


### PR DESCRIPTION
## Summary
- add release-driven deployment workflow for static app in web-sim/
- deploy to GitHub Pages on every published GitHub Release
- optionally deploy to Cloudflare Pages in the same workflow when secrets are configured
- document one-time setup and behavior in README
- document release-runbook linkage so publish step implies hosting refresh

## Ops details
- trigger: release.published (plus manual dispatch)
- workflow: .github/workflows/release-web-sim.yml
- Cloudflare secrets used when present: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_PAGES_PROJECT

## Outcome
Every release now refreshes hosted simulation automatically.